### PR TITLE
new base image report template

### DIFF
--- a/content/releases-and-versions/versions.md
+++ b/content/releases-and-versions/versions.md
@@ -6,15 +6,8 @@ weight: 2
 
 ## Hardware
 
-**Mac Mini**
-
-- 2.3GHz Quad Core CPU
-- 8GB RAM
-
-**Mac Pro**
-
-- 3.7GHz Quad Core CPU
-- 32GB RAM
+- **Mac Mini** 2.3GHz Quad Core/8GB
+- or **Mac Pro** 3.7GHz Quad Core/32GB
 
 ## System
 

--- a/content/releases-and-versions/versions.md
+++ b/content/releases-and-versions/versions.md
@@ -6,8 +6,8 @@ weight: 2
 
 ## Hardware
 
-- **Mac Mini** 2.3GHz Quad Core/8GB
-- or **Mac Pro** 3.7GHz Quad Core/32GB
+- **Mac Mini** 2.3GHz Quad Core / 8GB
+- or **Mac Pro** 3.7GHz Quad Core / 32GB
 
 ## System
 

--- a/content/releases-and-versions/versions.md
+++ b/content/releases-and-versions/versions.md
@@ -13,33 +13,33 @@ weight: 2
 
 - System Version `macOS 10.14.6 (18G2022)`
 - Kernel Version `Darwin 18.7.0`
-- Disk `300GB (Free Space: 48GB)`
+- Disk `322G (Free Space: 51G)`
 
 ## Pre-installed tools
 
 - Android tools `$HOME/programs/android-sdk-macosx`
-- curl `7.54.0`
 - cocoapods `1.8.4`
+- curl
 - dart `2.7.0`
-- docker
+- docker `19.03.5`
 - fastlane `2.138.0`
 - firebase `7.6.2`
 - flutter `1.12.13+hotfix.5 ($HOME/programs/flutter)`
 - gem `3.0.3`
 - git `2.24.1`
-- gradle `5.5.1`
+- gradle `N/A`
 - homebrew `2.2.1`
-- jq `1.6`
+- jq
 - node `12.14.0`
 - npm `6.13.4`
 - python `2.7.17`
 - python3 `3.7.5`
 - ruby `2.6.5p114`
-- ssh `7.9p1`
+- ssh
 - sudo
 - tar
 - unzip
-- wget `1.20.3`
+- wget
 - yarn `1.21.1`
 - zip
 
@@ -47,7 +47,7 @@ weight: 2
 
 This is the Xcode version used by default when you select `latest` in build settings. Other available versions are listed [here](#other-xcode-versions).
 
-Xcode path: `/Applications/Xcode-11.3.app`
+Xcode path: /Applications/Xcode-11.3.app
 
 With Xcode 11.3 build version 11C29 the following runtimes and devices are installed:
 

--- a/content/releases-and-versions/versions.md
+++ b/content/releases-and-versions/versions.md
@@ -6,8 +6,15 @@ weight: 2
 
 ## Hardware
 
-- Mac Mini
-- Mac Pro
+**Mac Mini**
+
+- 2.3GHz Quad Core CPU
+- 8GB RAM
+
+**Mac Pro**
+
+- 3.7GHz Quad Core CPU
+- 32GB RAM
 
 ## System
 

--- a/content/releases-and-versions/versions.md
+++ b/content/releases-and-versions/versions.md
@@ -1,45 +1,25 @@
 ---
 description: A list of software and versions available out-of-the-box on Codemagic.
-title: Software versions
+title: macOS Builder Specification
 weight: 2
 ---
+**System**
+
+- System Version `macOS 10.14.6 (18G2022)`
+- Kernel Version `Darwin 18.7.0`
+- Disk `300G (Free Space: 48G)
+
 **Dart and Flutter**
 
 - Dart `2.7.0`
 - Flutter `1.12.13+hotfix.5 ($HOME/programs/flutter)`
 
-**iOS tools**
-
-- Xcode
-
-`9.4.1 (9F2000) (/Applications/Xcode-9.4.app)`
-
-`10.0 (10A255) (/Applications/Xcode-10.app)`
-
-`10.1 (10B61) (/Applications/Xcode-10.1.app)`
-
-`10.2.1 (10E1001) (/Applications/Xcode-10.2.app)`
-
-`10.3 (10G8) (/Applications/Xcode-10.3.app)`
-
-`11.0 (11A420a) (/Applications/Xcode-11.app)`
-
-`11.1 (11A1027) (/Applications/Xcode-11.1.app)`
-
-`11.2.1 (11B500) (/Applications/Xcode-11.2.1.app)`
-
-`11.3 (11C29) (/Applications/Xcode-11.3.app)`
-
-
-- CocoaPods `1.8.4`
-
-**Android tools**
+**Pre-installed Tools**
 
 - Android tools `$HOME/programs/android-sdk-macosx`
-
-**Other tools**
-
 - curl `7.54.0`
+- cocoapods `1.8.4`
+- docker
 - fastlane `2.138.0`
 - firebase `7.6.2`
 - gem `3.0.3`
@@ -53,5 +33,100 @@ weight: 2
 - python3 `3.7.5`
 - ruby `2.6.5p114`
 - ssh `7.9p1`
+- sudo
+- tar
+- unzip
 - wget `1.20.3`
 - yarn `1.21.1`
+- zip
+
+**Xcode 11.3 (11C29)**
+
+Xcode path: `/Applications/Xcode-11.3.app`
+
+With Xcode 11.3 Build version 11C29 we install the following:
+
+***Runtimes***
+- iOS 10.0
+- iOS 10.1
+- iOS 10.2
+- iOS 10.3
+- iOS 11.0
+- iOS 11.1
+- iOS 11.2
+- iOS 11.3
+- iOS 11.4
+- iOS 12.0
+- iOS 12.1
+- iOS 12.2
+- iOS 12.4
+- iOS 13.0
+- iOS 13.1
+- iOS 13.2
+- iOS 13.3
+- tvOS 11.3
+- tvOS 13.3
+- watchOS 6.1
+
+***Devices***
+- iPhone 4s
+- iPhone 5
+- iPhone 5s
+- iPhone 6 Plus
+- iPhone 6
+- iPhone 6s
+- iPhone 6s Plus
+- iPhone SE
+- iPhone 7
+- iPhone 7 Plus
+- iPhone 8
+- iPhone 8 Plus
+- iPhone X
+- iPhone Xs
+- iPhone Xs Max
+- iPhone Xʀ
+- iPhone 11
+- iPhone 11 Pro
+- iPhone 11 Pro Max
+- iPad 2
+- iPad Retina
+- iPad Air
+- iPad mini 2
+- iPad mini 3
+- iPad mini 4
+- iPad Air 2
+- iPad Pro (9.7-inch)
+- iPad Pro (12.9-inch)
+- iPad (5th generation)
+- iPad Pro (12.9-inch) (2nd generation)
+- iPad Pro (10.5-inch)
+- iPad (6th generation)
+- iPad (7th generation)
+- iPad Pro (11-inch)
+- iPad Pro (12.9-inch) (3rd generation)
+- iPad mini (5th generation)
+- iPad Air (3rd generation)
+- Apple TV
+- Apple TV 4K
+- Apple TV 4K (at 1080p)
+- Apple Watch - 38mm
+- Apple Watch - 42mm
+- Apple Watch Series 2 - 38mm
+- Apple Watch Series 2 - 42mm
+- Apple Watch Series 3 - 38mm
+- Apple Watch Series 3 - 42mm
+- Apple Watch Series 4 - 40mm
+- Apple Watch Series 4 - 44mm
+- Apple Watch Series 5 - 40mm
+- Apple Watch Series 5 - 44mm
+
+**Available Xcode versions**
+
+- 11.2.1 (11B500) `/Applications/Xcode-11.2.1.app`
+- 11.1 (11A1027) `/Applications/Xcode-11.1.app`
+- 11.0 (11A420a) `/Applications/Xcode-11.app`
+- 10.3 (10G8) `/Applications/Xcode-10.3.app`
+- 10.2.1 (10E1001) `/Applications/Xcode-10.2.app`
+- 10.1 (10B61) `/Applications/Xcode-10.1.app`
+- 10.0 (10A255) `/Applications/Xcode-10.app`
+- 9.4.1 (9F2000) `/Applications/Xcode-9.4.app`

--- a/content/releases-and-versions/versions.md
+++ b/content/releases-and-versions/versions.md
@@ -6,14 +6,14 @@ weight: 2
 
 ## Hardware
 
-- **Mac Mini** 2.3GHz Quad Core / 8GB
-- or **Mac Pro** 3.7GHz Quad Core / 32GB
+- Mac Mini `2.3GHz Quad Core / 8GB`
+- Mac Pro `3.7GHz Quad Core / 32GB`
 
 ## System
 
-- System Version `macOS 10.14.6 (18G2022)`
-- Kernel Version `Darwin 18.7.0`
-- Disk `322G (Free Space: 51G)`
+- System version `macOS 10.14.6 (18G2022)`
+- Kernel version `Darwin 18.7.0`
+- Disk `322GB (Free Space: 51GB)`
 
 ## Pre-installed tools
 
@@ -47,9 +47,9 @@ weight: 2
 
 This is the Xcode version used by default when you select `latest` in build settings. Other available versions are listed [here](#other-xcode-versions).
 
-Xcode path: /Applications/Xcode-11.3.app
+Xcode path: `/Applications/Xcode-11.3.app`
 
-With Xcode 11.3 build version 11C29 the following runtimes and devices are installed:
+With Xcode `11.3` build version `11C29` the following runtimes and devices are installed:
 
 ### Runtimes
 

--- a/content/releases-and-versions/versions.md
+++ b/content/releases-and-versions/versions.md
@@ -1,27 +1,30 @@
 ---
-description: A list of software and versions available out-of-the-box on Codemagic.
-title: macOS Builder Specification
+description: A list of tools available out-of-the-box on Codemagic build machines.
+title: macOS build machine specification
 weight: 2
 ---
-**System**
+
+## Hardware
+
+- Mac Mini
+- Mac Pro
+
+## System
 
 - System Version `macOS 10.14.6 (18G2022)`
 - Kernel Version `Darwin 18.7.0`
-- Disk `300G (Free Space: 48G)
+- Disk `300GB (Free Space: 48GB)`
 
-**Dart and Flutter**
-
-- Dart `2.7.0`
-- Flutter `1.12.13+hotfix.5 ($HOME/programs/flutter)`
-
-**Pre-installed Tools**
+## Pre-installed tools
 
 - Android tools `$HOME/programs/android-sdk-macosx`
 - curl `7.54.0`
 - cocoapods `1.8.4`
+- dart `2.7.0`
 - docker
 - fastlane `2.138.0`
 - firebase `7.6.2`
+- flutter `1.12.13+hotfix.5 ($HOME/programs/flutter)`
 - gem `3.0.3`
 - git `2.24.1`
 - gradle `5.5.1`
@@ -40,13 +43,16 @@ weight: 2
 - yarn `1.21.1`
 - zip
 
-**Xcode 11.3 (11C29)**
+## Xcode 11.3 (11C29)
+
+This is the Xcode version used by default when you select `latest` in build settings. Other available versions are listed [here](#other-xcode-versions).
 
 Xcode path: `/Applications/Xcode-11.3.app`
 
-With Xcode 11.3 Build version 11C29 we install the following:
+With Xcode 11.3 build version 11C29 the following runtimes and devices are installed:
 
-***Runtimes***
+### Runtimes
+
 - iOS 10.0
 - iOS 10.1
 - iOS 10.2
@@ -68,7 +74,8 @@ With Xcode 11.3 Build version 11C29 we install the following:
 - tvOS 13.3
 - watchOS 6.1
 
-***Devices***
+### Devices
+
 - iPhone 4s
 - iPhone 5
 - iPhone 5s
@@ -120,7 +127,7 @@ With Xcode 11.3 Build version 11C29 we install the following:
 - Apple Watch Series 5 - 40mm
 - Apple Watch Series 5 - 44mm
 
-**Available Xcode versions**
+## Other Xcode versions
 
 - 11.2.1 (11B500) `/Applications/Xcode-11.2.1.app`
 - 11.1 (11A1027) `/Applications/Xcode-11.1.app`


### PR DESCRIPTION
- added Mac Mini and Mac Pro specification
- added system version and disk usage info
- dart & flutter moved to other tools, added more system tools
- separate section for default Xcode with runtimes and devices