### PR TITLE
Add Documentation For Custom Build Triggers with YAML Configuration

### DIFF
--- a/content/building/automatic-build-triggering.md
+++ b/content/building/automatic-build-triggering.md
@@ -77,9 +77,9 @@ Badge markdown has the following format: `(api.codemagic.io/apps/[appId]/[workfl
 
 Contact the Codemagic team to obtain the `x-auth-token`.
 
-## Custom build triggers with YAML Advanced Configuration
+## Custom build triggers with YAML configuration
 
-You can also configure custom build triggers when using Advanced Configuration Settings with a codemagic.yaml file. 
+You can also configure custom build triggers when using `codemagic.yaml` file for build configuration. 
 Build triggering in response to custom events can be set up by sending a `POST` request to the `https://api.codemagic.io/builds` endpoint. 
 
 `POST https://api.codemagic.io/builds`
@@ -88,7 +88,7 @@ Content:
 
         {
         "appId": "----appId----",
-        "fileWorkflowId": "Workflow Name in YAML File",
+        "fileWorkflowId": "Workflow name in YAML file",
         "branch": "master"
         }
 
@@ -96,7 +96,7 @@ Header:
 
 `"x-auth-token": "-----id-----"`
 
-The `fileWorkflowId` is the `workflow ID` provided in your codemagic.yaml configuration file shown below:
+The `fileWorkflowId` is the `workflow ID` provided in your `codemagic.yaml` configuration file shown below:
 ```
 workflows:
   my-workflow:                # workflow ID 
@@ -110,7 +110,7 @@ workflows:
     artifacts:
 ```
 
-The `appId` can be found from the URL of your App Build `https://codemagic.io/app/[APP_ID]]`
+The `appId` can be found from the URL of your app build: `https://codemagic.io/app/[appId]`
 
 ## Skipping builds
 

--- a/content/building/automatic-build-triggering.md
+++ b/content/building/automatic-build-triggering.md
@@ -77,6 +77,42 @@ Badge markdown has the following format: `(api.codemagic.io/apps/[appId]/[workfl
 
 Contact the Codemagic team to obtain the `x-auth-token`.
 
+**When Using YAML Confiiguration**
+
+You can also configure custom build triggers when using Advanced Configuration Settings with a codemagic.yaml file. 
+Build triggering in response to custom events can be set up by sending a `POST` request to the `https://api.codemagic.io/builds` endpoint. 
+
+`POST https://api.codemagic.io/builds`
+
+Content:
+
+        {
+        "appId": "----appId----",
+        "fileWorkflowId": "Workflow Name in YAML File",
+        "branch": "master"
+        }
+
+Header:
+
+`"x-auth-token": "-----id-----"`
+
+The `fileWorkflowId` is the `workflow ID` provided in your codemagic.yaml configuration file shown below:
+```
+workflows:
+  my-workflow:                # workflow ID 
+    name: My workflow name    # workflow name displayed in UI
+    environment:
+    cache:
+    triggering:
+    branch_patterns:
+    scripts:
+    publishing:
+    artifacts:
+```
+
+The `appId` can be found from the URL of your App Build `https://codemagic.io/app/[APP_ID]]`
+
+
 ## Skipping builds
 
 If you do not wish Codemagic to build a particular commit, include `[skip ci]` or `[ci skip]` in your commit message.

--- a/content/building/automatic-build-triggering.md
+++ b/content/building/automatic-build-triggering.md
@@ -77,7 +77,7 @@ Badge markdown has the following format: `(api.codemagic.io/apps/[appId]/[workfl
 
 Contact the Codemagic team to obtain the `x-auth-token`.
 
-**When Using YAML Confiiguration**
+## Custom build triggers with YAML Advanced Configuration
 
 You can also configure custom build triggers when using Advanced Configuration Settings with a codemagic.yaml file. 
 Build triggering in response to custom events can be set up by sending a `POST` request to the `https://api.codemagic.io/builds` endpoint. 

--- a/content/building/automatic-build-triggering.md
+++ b/content/building/automatic-build-triggering.md
@@ -112,7 +112,6 @@ workflows:
 
 The `appId` can be found from the URL of your App Build `https://codemagic.io/app/[APP_ID]]`
 
-
 ## Skipping builds
 
 If you do not wish Codemagic to build a particular commit, include `[skip ci]` or `[ci skip]` in your commit message.


### PR DESCRIPTION
After speaking with Slack support about triggering builds via the REST API when using YAML Advanced Configuration, I was given information not provided in the documentation. I added the specifications for making REST API calls to trigger build using YAML configuration by highlighting the use of "fileWorkflowId" rather than "workflowId" and where to get your fileWorkflowId from the YAML file. 