### PR TITLE
Search works for query with a dot

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -109,12 +109,12 @@ function matchPositionObject(builder) {
   builder.pipeline.before(lunr.stemmer, pipelineFunction)
   builder.metadataWhitelist.push('positionObject')
 
-  var searchQueryRemoveDots = function(query) {
-    query.str = query.str.replace('.', '')
+  var removeLeadingDot = function(query) {
+    query.str = query.str.replace(/^\./, '')
     return query
   }
-  lunr.Pipeline.registerFunction(searchQueryRemoveDots, 'searchQueryRemoveDots')
-  builder.searchPipeline.before(lunr.stemmer, searchQueryRemoveDots)
+  lunr.Pipeline.registerFunction(removeLeadingDot, 'removeLeadingDot')
+  builder.searchPipeline.before(lunr.stemmer, removeLeadingDot)
 }
 
 function getSearchIndex(pages) {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -108,6 +108,13 @@ function matchPositionObject(builder) {
   lunr.Pipeline.registerFunction(pipelineFunction, 'positionObjMetadata')
   builder.pipeline.before(lunr.stemmer, pipelineFunction)
   builder.metadataWhitelist.push('positionObject')
+
+  var searchQueryRemoveDots = function(query) {
+    query.str = query.str.replace('.', '')
+    return query
+  }
+  lunr.Pipeline.registerFunction(searchQueryRemoveDots, 'searchQueryRemoveDots')
+  builder.searchPipeline.before(lunr.stemmer, searchQueryRemoveDots)
 }
 
 function getSearchIndex(pages) {
@@ -265,7 +272,7 @@ function getResults(index, query) {
   }
 
   return index.lunrIndex
-    .search(query + '~1')
+    .search(query)
     .slice(0, 16)
     .map(function(result) {
       var positions = { title: [], content: [] }

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -265,7 +265,7 @@ function getResults(index, query) {
   }
 
   return index.lunrIndex
-    .search(query)
+    .search(query + '~1')
     .slice(0, 16)
     .map(function(result) {
       var positions = { title: [], content: [] }


### PR DESCRIPTION
Added fuzziness parameter equal to 1
[Fuzzy matches](https://lunrjs.com/guides/searching.html#fuzzy-matches)

### QA

✅ search picks up names with dots, like `.p12` and `.mobileprovision`
✅ search works as expected for other queries
✅ search for queries with two leading dots, like `.something .some-something`