### PR TITLE
Update yaml.md with CERTIFICATE_PRIVATE_KEY tutorial link for iOS automatic code signing

### DIFF
--- a/content/building/yaml.md
+++ b/content/building/yaml.md
@@ -173,7 +173,7 @@ In order to use **automatic code signing** and have Codemagic manage signing cer
 
 * `CERTIFICATE_PRIVATE_KEY`
 
-  A RSA 2048 bit private key to be included in the signing certificate. Read more about it [here](https://help.apple.com/xcode/mac/current/#/dev1c7c2c67d).
+  A RSA 2048 bit private key to be included in the signing certificate. Read more about it [here](https://help.apple.com/xcode/mac/current/#/dev1c7c2c67d). Tutorial for creating the 2048 bit RSA key - [link] (https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 
 {{<notebox>}}
 Alternatively, each property can be specified in the [scripts](#scripts) section as a command argument to programs with dedicated flags. See the details [here](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/fetch%E2%80%91signing%E2%80%91files.md#--issuer-idissuer_id). In that case, the environment variables will be fallbacks for missing values in scripts.


### PR DESCRIPTION
There has been some confusion about the CERTIFICATE_PRIVATE_KEY variable in automatic code signing with .yaml file. Users didn't know where to find it or what key we are looking for. Included a tutorial from Github how to create it. 