### PR TITLE
explain project path to load firebase config

### DIFF
--- a/content/custom-scripts/load-firebase-configuration.md
+++ b/content/custom-scripts/load-firebase-configuration.md
@@ -15,7 +15,7 @@ Instead of committing the Firebase config files to your repository, you can uplo
         echo $ANDROID_FIREBASE_SECRET | base64 --decode > $FCI_BUILD_DIR/android/app/google-services.json
         echo $IOS_FIREBASE_SECRET | base64 --decode > $FCI_BUILD_DIR/ios/Runner/GoogleService-Info.plist
 
-    In case your project is in a nested folder structure, you need to reflect it. It can be done like
+    In case your project is in a nested folder structure, it has to be reflected and the script should be following: 
 
         #!/usr/bin/env sh
         set -e # exit on first failed command

--- a/content/custom-scripts/load-firebase-configuration.md
+++ b/content/custom-scripts/load-firebase-configuration.md
@@ -10,10 +10,17 @@ Instead of committing the Firebase config files to your repository, you can uplo
 2.  Add the following **pre-build** script echoing your variables to load the Firebase configuration in Codemagic.
 
         #!/usr/bin/env sh
-
         set -e # exit on first failed command
-        
-        PROJECT_ROOT=$FCI_BUILD_DIR/myproject           # ADD YOUR PROJECT FOLDER PATH HERE
+
+        echo $ANDROID_FIREBASE_SECRET | base64 --decode > $FCI_BUILD_DIR/android/app/google-services.json
+        echo $IOS_FIREBASE_SECRET | base64 --decode > $FCI_BUILD_DIR/ios/Runner/GoogleService-Info.plist
+
+    In case your project is in a nested folder structure, you need to reflect it. It can be done like
+
+        #!/usr/bin/env sh
+        set -e # exit on first failed command
+
+        PROJECT_ROOT=$FCI_BUILD_DIR/myproject/path      # ADD YOUR PROJECT FOLDER PATH HERE
 
         echo $ANDROID_FIREBASE_SECRET | base64 --decode > $PROJECT_ROOT/android/app/google-services.json
         echo $IOS_FIREBASE_SECRET | base64 --decode > $PROJECT_ROOT/ios/Runner/GoogleService-Info.plist


### PR DESCRIPTION
Not all the users know that $FCI_BUILD_DIR is the folder with repo content, not the folder containing the repo folder.
Next changes will make it less ambiguous, because at least one user had hard time trying to specify it as `PROJECT_ROOT=$FCI_BUILD_DIR/<repository_name>`