### PR TITLE
Update Native iOS and Native Android documentation for clarity

### DIFF
--- a/content/yaml/building-a-native-android-app.md
+++ b/content/yaml/building-a-native-android-app.md
@@ -7,7 +7,7 @@ weight: 3
 
 The necessary command for building native Android application goes under `scripts` in the [overall architecture](../yaml/yaml/#template) in the `codemagic.yaml` file. For Android (built with gradle), the script looks like this:
 
-    - ./gradlew build
+    - cd $FCI_BUILD_DIR && ./gradlew build
 
 ## Testing, code signing and publishing an Android app
 

--- a/content/yaml/building-a-native-ios-app.md
+++ b/content/yaml/building-a-native-ios-app.md
@@ -14,13 +14,19 @@ Codemagic uses the [xcode-project](https://github.com/codemagic-ci-cd/cli-tools/
 
 For building an unsigned iOS app (.app), you need to run the following command in the scripts section:
 
-    - xcodebuild build -workspace "MyXcodeWorkspace.xcworkspace" -scheme "MyScheme" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+    - |
+      cd ios
+      xcodebuild build -workspace "MyXcodeWorkspace.xcworkspace" \
+                       -scheme "MyScheme" \
+                       CODE_SIGN_INDENTITY="" \
+                        CODE_SIGNING_REQUIRED=NO \
+                        CODE_SIGNING_ALLOWED=NO
 
 ## Building a native iOS app archive (.ipa)
 
 For building an archived iOS app (.ipa), you need to run the following command in the scripts section:
 
-    - xcode-project build-ipa --project "MyXcodeProject.xcodeproj" --scheme "MyScheme"
+    - xcode-project build-ipa --project "ios/MyXcodeProject.xcodeproj" --scheme "MyScheme"
 
 {{<notebox>}}Read more about different schemes in [Apple documentation](https://help.apple.com/xcode/mac/current/#/dev0bee46f46).{{</notebox>}} 
 

--- a/content/yaml/building-a-native-ios-app.md
+++ b/content/yaml/building-a-native-ios-app.md
@@ -15,7 +15,7 @@ Codemagic uses the [xcode-project](https://github.com/codemagic-ci-cd/cli-tools/
 For building an unsigned iOS app (.app), you need to run the following command in the scripts section:
 
     - |
-      cd ios
+      cd $FCI_BUILD_DIR
       xcodebuild build -workspace "MyXcodeWorkspace.xcworkspace" \
                        -scheme "MyScheme" \
                        CODE_SIGN_INDENTITY="" \
@@ -26,7 +26,7 @@ For building an unsigned iOS app (.app), you need to run the following command i
 
 For building an archived iOS app (.ipa), you need to run the following command in the scripts section:
 
-    - xcode-project build-ipa --project "ios/MyXcodeProject.xcodeproj" --scheme "MyScheme"
+    - xcode-project build-ipa --project "$FCI_BUILD_DIR/MyXcodeProject.xcodeproj" --scheme "MyScheme"
 
 {{<notebox>}}Read more about different schemes in [Apple documentation](https://help.apple.com/xcode/mac/current/#/dev0bee46f46).{{</notebox>}} 
 

--- a/content/yaml/building-a-native-ios-app.md
+++ b/content/yaml/building-a-native-ios-app.md
@@ -19,8 +19,8 @@ For building an unsigned iOS app (.app), you need to run the following command i
       xcodebuild build -workspace "MyXcodeWorkspace.xcworkspace" \
                        -scheme "MyScheme" \
                        CODE_SIGN_INDENTITY="" \
-                        CODE_SIGNING_REQUIRED=NO \
-                        CODE_SIGNING_ALLOWED=NO
+                       CODE_SIGNING_REQUIRED=NO \
+                       CODE_SIGNING_ALLOWED=NO
 
 ## Building a native iOS app archive (.ipa)
 


### PR DESCRIPTION
**Description**

While by default when it comes to Native iOS and Native Android, we are actually in the right directory to execute the following commands, we still decided to change the code snippets a bit.

Due to the fact that we get many questions that could be avoided when people understood that changing directories and running the command should be done under the same script, we discussed with Mikhail that it could help if multiline scripts and changing directories would also be visible in places where users might see them better.

Using $FCI_BUILD_DIR also indicates to new users that we have environment variables that they can use to make their experience easier.

**Possible to-do's**
- make similar changes to elsewhere in the documentation
- find a place where to explain that each script is actually ran in a new shell
(this being the reason why the following would not work for example if we had a React Native app and wanted to build for android)

```
- cd android 
- ./gradlew build
```
