### PR TITLE
Fix build-universal-apk usage

### DIFF
--- a/content/building/building-android-app-bundles.md
+++ b/content/building/building-android-app-bundles.md
@@ -3,7 +3,7 @@ title: Building Android App Bundles
 weight: 6
 ---
 
-You can build your app in [Android App Bundle](https://developer.android.com/guide/app-bundle) (`.aab`) format for publishing to Google Play. When you upload your app in `.aab` format, app APKs will be dynamically created and optimized for user's device configuration when the app is installed from Google Play Store.
+You can build your app in [Android App Bundle](https://developer.android.com/guide/app-bundle) (`.aab`) format for publishing to Google Play. When you upload your app in `.aab` format, app  .apk(s) will be dynamically created and optimized for user's device configuration when the app is installed from Google Play Store.
 
 {{<notebox>}}
 
@@ -24,6 +24,6 @@ In order to upload your Android App Bundle to Google Play, you will need to:
 1. Build the app in **Release** mode.
 2. Set up [Android code signing](https://docs.codemagic.io/code-signing/android-code-signing/) in Codemagic to sign the app bundle.
 3. Set up [publishing to Google Play](https://docs.codemagic.io/publishing/publishing-to-google-play/) in Codemagic to upload your app bundle to one of Google Play tracks.
-4. [Enroll your app into app signing by Google Play](https://support.google.com/googleplay/android-developer/answer/7384423) to have Google sign the APKs that are generated from the app bundle during installation.
+4. [Enroll your app into app signing by Google Play](https://support.google.com/googleplay/android-developer/answer/7384423) to have Google sign the .apk(s) that are generated from the app bundle during installation.
 
-When you enroll an app into app signing by Google Play, Google will manage your app's signing key for you and use it to sign the APKs for distribution. Note that the app must be signed with the same key throughout its lifecycle, so if the app has already been uploaded to Google Play, make sure to export and upload your original key to Google Play for app signing. It is then recommended to create a new key ("upload key") for signing your app updates and uploading them to Google Play.
+When you enroll an app into app signing by Google Play, Google will manage your app's signing key for you and use it to sign the .apk for distribution. Note that the app must be signed with the same key throughout its lifecycle, so if the app has already been uploaded to Google Play, make sure to export and upload your original key to Google Play for app signing. It is then recommended to create a new key ("upload key") for signing your app updates and uploading them to Google Play.

--- a/content/code-signing/android-code-signing.md
+++ b/content/code-signing/android-code-signing.md
@@ -8,7 +8,7 @@ Code signing is required for distributing your Android app to Google Play store.
 
 ## Requirements
 
-To receive a signed release APK of your app on Codemagic, you will have to:
+To receive a signed release .apk of your app on Codemagic, you will have to:
  
 1. [Prepare your Flutter project for code signing](https://docs.codemagic.io/code-signing/android-code-signing/#preparing-your-flutter-project-for-code-signing)
 

--- a/content/publishing/publishing-to-google-play.md
+++ b/content/publishing/publishing-to-google-play.md
@@ -44,6 +44,6 @@ The very first version of the app must be added to Google Play manually. You can
    - Alpha --- publish for testing with a small group of trusted users
    - Beta --- publish for testing to a wider set of users
    - Production --- release the app to production
-5. If you want to publish the APK even when one or more tests fail, mark the **Publish even if tests fail** checkbox.
+5. If you want to publish the .apk even when one or more tests fail, mark the **Publish even if tests fail** checkbox.
 6. Select **Enable Google Play publishing** at the top of the section to enable publishing.
 7. Click **Save** to finish the setup.

--- a/content/yaml/building-a-flutter-app.md
+++ b/content/yaml/building-a-flutter-app.md
@@ -18,7 +18,7 @@ Set up local properties
 
 ### Building universal .apk(s) from existing app bundle(s) with user-specified keys
 
-If your app settings in Codemagic have building Android App Bundles enabled, we will automatically include a script for generating a signed `app-universal.apk` during the YAML export. If you are creating a YAML file from a scratch, add the following script to receive those file(s):
+If your app settings in Codemagic have building Android App Bundles enabled, we will automatically include a script for generating a signed `app-universal.apk` during the YAML export. If you are creating a YAML file from a scratch, add the following script to receive the .apk file(s):
 
     - android-app-bundle build-universal-apk \
         --bundle 'project_directory/build/**/outputs/**/*.aab' \

--- a/content/yaml/building-a-flutter-app.md
+++ b/content/yaml/building-a-flutter-app.md
@@ -16,16 +16,18 @@ Set up local properties
 
     - flutter build apk --release
 
-### Building universal .apk from an existing app bundle with user-specified keys
+### Building universal .apk(s) from existing app bundle(s) with user-specified keys
 
-If your app settings in Codemagic have building Android App Bundles enabled, we will automatically include a script for generating a signed `app-universal.apk` during the YAML export. If you are creating a YAML file from a scratch, add the following script to receive that file:
+If your app settings in Codemagic have building Android App Bundles enabled, we will automatically include a script for generating a signed `app-universal.apk` during the YAML export. If you are creating a YAML file from a scratch, add the following script to receive those file(s):
 
     - android-app-bundle build-universal-apk \
-        --pattern 'project_directory/build/**/outputs/**/*.aab' \
+        --bundle 'project_directory/build/**/outputs/**/*.aab' \
         --ks /tmp/keystore.keystore \
         --ks-pass $CM_KEYSTORE_PASSWORD \
         --ks-key-alias $CM_KEY_ALIAS_USERNAME \
         --key-pass $CM_KEY_ALIAS_PASSWORD
+
+Please make sure to wrap the `--bundle` pattern in single quotes. If `--bundle` option is not specified, default glob pattern `**/*.aab` will be used.
 
 More information about Android code signing can be found [here](../yaml/distribution/#setting-up-code-signing-for-android).
 

--- a/content/yaml/runninglocally.md
+++ b/content/yaml/runninglocally.md
@@ -40,9 +40,9 @@ Note that `--project` option can be either a path literal, or a glob pattern to 
 
 `--profile` option can be a glob pattern as well (Default is `$HOME/Library/MobileDevice/Provisioning Profiles/*.mobileprovision`).
 
-## Generate a universal APK with user specified keys from app bundle
+## Generate universal .apk(s) with user specified keys from app bundle
 
-To build APK(s) from the app bundle(s) found with `/path/to/**/*.aab` glob pattern with keystore `/path/to/keystore.keystore`, `KEYSTORE_PASSWORD`, `KEY_ALIAS` and `KEY_PASSWORD`, use the [android-app-bundle](https://github.com/codemagic-ci-cd/cli-tools/tree/master/docs/android-app-bundle#android-app-bundle) tool:
+To build .apk files(s) from the app bundle(s) found with `/path/to/**/*.aab` glob pattern with keystore `/path/to/keystore.keystore`, `KEYSTORE_PASSWORD`, `KEY_ALIAS` and `KEY_PASSWORD`, use the [android-app-bundle](https://github.com/codemagic-ci-cd/cli-tools/tree/master/docs/android-app-bundle#android-app-bundle) tool:
 
     android-app-bundle build-universal-apk \
         --bundle '/path/to/**/*.aab' \

--- a/content/yaml/runninglocally.md
+++ b/content/yaml/runninglocally.md
@@ -29,21 +29,29 @@ To initialize keychain at system default keychain path with empty keychain passw
     keychain initialize
     keychain add-certificates --certificate /path/to/certificate.p12 --certificate-password CERTIFICATE_PASSWORD
 
+Note that `--certificate` option can be either a path literal, or a glob pattern to match certificates.
+
 To use the provisioning profile from `/path/to/profile.mobileprovision` in your Xcode project `/path/to/MyProject.xcodeproj` and generate an .ipa archive using `MyScheme` scheme, use [xcode-project](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/xcode-project/README.md#xcode-project) with the following command:
 
     xcode-project use-profiles --project /path/to/MyProject.xcodeproj --profile /path/to/profile.mobileprovision
     xcode-project build-ipa --project /path/to/MyProject.xcodeproj --scheme MyScheme
 
+Note that `--project` option can be either a path literal, or a glob pattern to match projects in working directory (Default is `**/*.xcodeproj`).
+
+`--profile` option can be a glob pattern as well (Default is `$HOME/Library/MobileDevice/Provisioning Profiles/*.mobileprovision`).
+
 ## Generate a universal APK with user specified keys from app bundle
 
-To build an APK from the app bundle `/path/to/my-app.aab` with keystore `/path/to/keystore.keystore`, `KEYSTORE_PASSWORD`, `KEY_ALIAS` and `KEY_PASSWORD`, use the [android-app-bundle](https://github.com/codemagic-ci-cd/cli-tools/tree/master/docs/android-app-bundle#android-app-bundle) tool:
+To build APK(s) from the app bundle(s) found with `/path/to/**/*.aab` glob pattern with keystore `/path/to/keystore.keystore`, `KEYSTORE_PASSWORD`, `KEY_ALIAS` and `KEY_PASSWORD`, use the [android-app-bundle](https://github.com/codemagic-ci-cd/cli-tools/tree/master/docs/android-app-bundle#android-app-bundle) tool:
 
     android-app-bundle build-universal-apk \
-        --bundle 'path/to/my-app.aab' \
+        --bundle '/path/to/**/*.aab' \
         --ks /path/to/keystore.keystore \
         --ks-pass KEYSTORE_PASSWORD \
         --ks-key-alias KEY_ALIAS \
         --key-pass KEY_PASSWORD
+
+If `--bundle` option is not specified, default glob pattern `**/*.aab` will be used. Please make sure to wrap the pattern in single quotes.
 
 {{<notebox>}}
 Alternatively to entering `ISSUER_ID`, `KEY_IDENTIFIER`, `PRIVATE_KEY`, `CERTIFICATE_PASSWORD`,  `KEYSTORE_PASSWORD`, `KEY_PASSWORD` in plaintext, it may also be specified using an `@env:` prefix followed by an environment variable name, or `@file:` prefix followed by a path to the file containing the value. Example: `@env:<variable>` uses the value in the environment variable named `<variable>`, and `@file:<file_path>` uses the value from file at `<file_path>`.


### PR DESCRIPTION
There was an error, `build-universal-apk` has the option `--bundle`, not `--pattern` (that was changed).
Also would like to mention about possibilities to use glob patterns with cli tools.
Multiples apks can be generated if there are different .aab (matched by pattern), so better make plural.
Using no quotes or double quotes leads to some edge case complications, so it's better just to ask to use single quotes.