### PR TITLE
say to change custom script dir

### DIFF
--- a/content/building/custom-scripts.md
+++ b/content/building/custom-scripts.md
@@ -7,6 +7,10 @@ You can customize the Codemagic workflow by running custom scripts before and af
 
 In the UI, the spots for injecting custom scripts are marked by **'+'** signs between the sections. Click on **'+'** to expand the section and add your script in the appropriate section. You can run custom scripts in post-clone, pre-test, post-test, pre-build, post-build, pre-publish and post-publish phases. The scripts can be run in any language, simply define the language with a shebang line. For example, `#!/usr/bin/env python`.
 
+{{<notebox>}}
+Please note that custom scripts are **always** executed from the absolute path to the cloned repository (`/Users/builder/clone` which can also be found with environment variable `FCI_BUILD_DIR`). If your project is not in the repository root and you want to access it from script, you will need to move to the needed directory inside the script.
+{{</notebox>}}
+
 Using `codemagic.yaml` for build configuration allows for even greater customization of builds. Read more about it in [Configuration as code (YAML)](./yaml/).
 
 {{<notebox>}}

--- a/content/building/custom-scripts.md
+++ b/content/building/custom-scripts.md
@@ -8,7 +8,7 @@ You can customize the Codemagic workflow by running custom scripts before and af
 In the UI, the spots for injecting custom scripts are marked by **'+'** signs between the sections. Click on **'+'** to expand the section and add your script in the appropriate section. You can run custom scripts in post-clone, pre-test, post-test, pre-build, post-build, pre-publish and post-publish phases. The scripts can be run in any language, simply define the language with a shebang line. For example, `#!/usr/bin/env python`.
 
 {{<notebox>}}
-Please note that custom scripts are **always** executed from the absolute path to the cloned repository (`/Users/builder/clone` which can also be found with environment variable `FCI_BUILD_DIR`). If your project is not in the repository root and you want to access it from script, you will need to move to the needed directory inside the script.
+Please note that custom scripts are always executed from the absolute path to the cloned repository which is located at `/Users/builder/clone` and can also be accessed using the environment variable `FCI_BUILD_DIR`. If your project is not in the repository root and you want to access it from a script, you will need to move to the needed directory inside the script.
 {{</notebox>}}
 
 Using `codemagic.yaml` for build configuration allows for even greater customization of builds. Read more about it in [Configuration as code (YAML)](./yaml/).


### PR DESCRIPTION
Some users thought that if they have project file path specified, custom scripts will also be run from it. But it's not the case, custom scripts are always run from root.