### PR TITLE
Add comment about new aab selection

### DIFF
--- a/content/building/building-android-app-bundles.md
+++ b/content/building/building-android-app-bundles.md
@@ -15,7 +15,7 @@ Building an Android App Bundle requires additional configuration as described in
 
 ## Enable building app bundles in Codemagic
 
-In the **Build section** of app settings, tick **Android** and then check **Build Android App Bundles** under **Build for platforms**.
+In the **Build section** of app settings, tick **Android** and then choose **Android app bundle (AAB)** for the **Android build format**.
 
 ## Prepare the app bundle for uploading to Google Play
 


### PR DESCRIPTION
We now allow you choose between three ways to build Android projects: APK (default, same as before), AAB with universal APK (same as before when "build AAB" was checked), and just AAB (new). Consequently, there is now a dropdown with three choices instead of a checkbox.

Preferred option is the new one - AAB as it skips generating the universal APK, therefore speeding up the build.