### PR TITLE
Fix ssh-keygen command for newer Mac OS versions

### DIFF
--- a/content/yaml/distribution.md
+++ b/content/yaml/distribution.md
@@ -40,7 +40,7 @@ In order to use **automatic code signing** and have Codemagic manage signing cer
 
   A RSA 2048 bit private key to be included in the [signing certificate](https://help.apple.com/xcode/mac/current/#/dev1c7c2c67d) that Codemagic creates. You can use an existing key or create a new 2048 bit RSA key by running the following command in your terminal:
 
-      ssh-keygen -t rsa -b 2048 -f ~/Desktop/codemagic_private_key -q -N ""
+      ssh-keygen -t rsa -b 2048 -m PEM -f ~/Desktop/codemagic_private_key -q -N ""
 
 {{<notebox>}}
 Alternatively, each property can be specified in the scripts section as a command argument to programs with dedicated flags. See the details [here](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/fetch-signing-files.md#--issuer-idissuer_id). In that case, the environment variables will be fallbacks for missing values in scripts.


### PR DESCRIPTION
User reported that the provided ssh-keygen command did not work for their certificates. This is because it generates an "OPENSSH" private key by default with newer versions of Mac OS.
Update command with an extra format specifier to force the PEM RSA format.

Source https://serverfault.com/a/941893