### PR TITLE
update backend ip address

### DIFF
--- a/content/getting-started/adding-apps-from-custom-sources.md
+++ b/content/getting-started/adding-apps-from-custom-sources.md
@@ -53,7 +53,7 @@ After you have added the public key to your repository settings, finish adding t
 
 To allow Codemagic access the private repository, the following IP addresses need to be whitelisted:
 
-1. `34.74.32.93` - used by our backend for getting basic information about the repository
+1. `34.74.4.65` - used by our backend for getting basic information about the repository
 2. `192.159.66.80/28` - used by our builder servers to download the code and build it
 
 ## Modifying repository access settings


### PR DESCRIPTION
during the last major celery failure we recreated the GCP instance which lead to the change of IP address

NB: I wonder whether we need to send a notification to users about this change as those who already have the old IP in their firewalls may now experience connectivity issues.