### PR TITLE
update publishing description

### DIFF
--- a/content/yaml/building-a-native-ios-app.md
+++ b/content/yaml/building-a-native-ios-app.md
@@ -117,4 +117,4 @@ The following example shows a workflow that can be used to publish your iOS app 
         publishing:
             app_store_connect:                 
             apple_id: your_apple_id@example.com  # PUT YOUR APPLE ID HERE  
-            password: Encrypted(...)
+            password: Encrypted(...) # PUT YOUR APP-SPECIFIC-PASSWORD HERE https://support.apple.com/en-us/HT204397


### PR DESCRIPTION
Publishing password may be misleading as appleID password, but in fact it is not - we require an app specific password associated with the apple ID instead.