### PR TITLE
iOS: encrypt content of key files, not key files themselves.

### DIFF
--- a/content/yaml/distribution.md
+++ b/content/yaml/distribution.md
@@ -16,7 +16,7 @@ All generated artifacts can be published to external services. The available int
 Codemagic uses the [keychain](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/keychain/README.md#keychain) utility to manage macOS keychains and certificates.
 {{</notebox>}}
 
-In order to use **automatic code signing** and have Codemagic manage signing certificates and provisioning profiles on your behalf, you need to configure API access to App Store Connect and define the environment variables listed below. Make sure to [encrypt](#encrypting-sensitive-data) the values of the variables before adding them to the configuration file. For keys, encrypt the content of the key files, not the files themselves.
+In order to use **automatic code signing** and have Codemagic manage signing certificates and provisioning profiles on your behalf, you need to configure API access to App Store Connect and define the environment variables listed below. Make sure to [encrypt](#encrypting-sensitive-data) the values of the variables before adding them to the configuration file. For keys, encrypt the content of the key files, not the key files themselves.
 
 * `APP_STORE_CONNECT_PRIVATE_KEY`
 

--- a/content/yaml/distribution.md
+++ b/content/yaml/distribution.md
@@ -16,7 +16,7 @@ All generated artifacts can be published to external services. The available int
 Codemagic uses the [keychain](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/keychain/README.md#keychain) utility to manage macOS keychains and certificates.
 {{</notebox>}}
 
-In order to use **automatic code signing** and have Codemagic manage signing certificates and provisioning profiles on your behalf, you need to configure API access to App Store Connect and define the environment variables listed below. Make sure to [encrypt](#encrypting-sensitive-data) the values of the variables before adding them to the configuration file.
+In order to use **automatic code signing** and have Codemagic manage signing certificates and provisioning profiles on your behalf, you need to configure API access to App Store Connect and define the environment variables listed below. Make sure to [encrypt](#encrypting-sensitive-data) the values of the variables before adding them to the configuration file. For keys, encrypt the content of the key files, not the files themselves.
 
 * `APP_STORE_CONNECT_PRIVATE_KEY`
 


### PR DESCRIPTION
add comment for iOS code signing to not encrypt key files themselves, but content of key files
https://codemagicio.slack.com/archives/CEKE2KZ37/p1599227990290100?thread_ts=1599201827.281000&cid=CEKE2KZ37
