### PR TITLE
Improvement/new env vars

### DIFF
--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -26,7 +26,7 @@ Here you'll find some of the read-only environment variables explained.
 | BUILD_NUMBER             | Number of the build for this project in Codemagic                                                               |
 | FLUTTER_ROOT             | Absolute path to Flutter SDK                                                                                    |
 | FCI_BRANCH               | The current branch being built, for pull requests it is the source branch                                       |
-| FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form owner_name/repository_name                 |
+| FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form owner_name/repository_name. Unset in case of custom source added repository|
 | FCI_COMMIT               | Commit hash that is currently being built by Codemagic, for pull request builds it is the hash of the source commit |
 | FCI_PULL_REQUEST         | `true`, if the current build is building a pull request, `false` otherwise                                      |
 | FCI_PULL_REQUEST_NUMBER  | Set to Integer ID of the pull request for the Git provider (Bitbucket, Github etc) if the current build is building a pull request, unset otherwise|

--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -25,9 +25,13 @@ Here you'll find some of the read-only environment variables explained.
 | CONTINUOUS_INTEGRATION   | true                                                                                                            |
 | BUILD_NUMBER             | Number of the build for this project in Codemagic                                                               |
 | FLUTTER_ROOT             | Absolute path to Flutter SDK                                                                                    |
-| FCI_BRANCH               | The current branch being built, for pull requests it is the destination branch                                  |
+| FCI_BRANCH               | The current branch being built, for pull requests it is the source branch                                       |
+| FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form owner_name/repository_name                 |
 | FCI_COMMIT               | Commit hash that is currently being built by Codemagic, for pull request builds it is the hash of the source commit |
-| FCI_CLONE_UNSHALLOW      | If set to `true`, performs a full clone of the repository instead of top 50 commits                              |
+| FCI_PULL_REQUEST         | `true`, if the current build is building a pull request, unset otherwise                                        |
+| FCI_PULL_REQUEST_NUMBER  | Set to Integer ID of the pull request for the Git provider (Bitbucket, Github etc) if the current build is building a pull request, unset otherwise|
+| FCI_CLONE_UNSHALLOW      | If set to `true`, performs a full clone of the repository instead of top 50 commits                             |
+| FCI_CLONE_DEPTH          | Specifies the clone depth which allows to decrease default fetching time when is set lower than 50              |
 | FCI_PROJECT_ID           | UUID of the project that is being built                                                                         |
 | FCI_BUILD_ID             | UUID of the build                                                                                               |
 | FCI_TEST_STEP_STATUS     | Test step status, success or failure                                                                            |

--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -23,7 +23,8 @@ Here you'll find some of the read-only environment variables explained.
 |--------------------------|-----------------------------------------------------------------------------------------------------------------|
 | CI                       | true                                                                                                            |
 | CONTINUOUS_INTEGRATION   | true                                                                                                            |
-| BUILD_NUMBER             | Number of the build for this project in Codemagic                                                               |
+| BUILD_NUMBER             | Number of the build for this project in Codemagic for the given workflow                                        |
+| PROJECT_BUILD_NUMBER     | Number of the build for this project in Codemagic                                                               |
 | FLUTTER_ROOT             | Absolute path to Flutter SDK                                                                                    |
 | FCI_BRANCH               | The current branch being built, for pull requests it is the source branch                                       |
 | FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form owner_name/repository_name. Unset in case of custom source added repository|

--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -27,12 +27,12 @@ Here you'll find some of the read-only environment variables explained.
 | PROJECT_BUILD_NUMBER     | Number of the build for this project in Codemagic                                                               |
 | FLUTTER_ROOT             | Absolute path to Flutter SDK                                                                                    |
 | FCI_BRANCH               | The current branch being built, for pull requests it is the source branch                                       |
-| FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form owner_name/repository_name. Unset in case of custom source added repository|
+| FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form `owner_name/repository_name`. Unset for repositories added from custom source|
 | FCI_COMMIT               | Commit hash that is currently being built by Codemagic, for pull request builds it is the hash of the source commit |
 | FCI_PULL_REQUEST         | `true`, if the current build is building a pull request, `false` otherwise                                      |
 | FCI_PULL_REQUEST_NUMBER  | Set to Integer ID of the pull request for the Git provider (Bitbucket, Github etc) if the current build is building a pull request, unset otherwise|
-| FCI_CLONE_UNSHALLOW      | If set to `true`, performs a full clone of the repository instead of top 50 commits                             |
-| FCI_CLONE_DEPTH          | Specifies the clone depth which allows to decrease default fetching time when is set lower than 50              |
+| FCI_CLONE_UNSHALLOW      | If set to `true` performs a full clone of the repository instead of top 50 commits                             |
+| FCI_CLONE_DEPTH          | Specifies the number of commits to be fetched from the repository when cloning, default: 50. Specifying a smaller number can decrease the default fetching time|
 | FCI_PROJECT_ID           | UUID of the project that is being built                                                                         |
 | FCI_BUILD_ID             | UUID of the build                                                                                               |
 | FCI_TEST_STEP_STATUS     | Test step status, success or failure                                                                            |

--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -28,7 +28,7 @@ Here you'll find some of the read-only environment variables explained.
 | FCI_BRANCH               | The current branch being built, for pull requests it is the source branch                                       |
 | FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form owner_name/repository_name                 |
 | FCI_COMMIT               | Commit hash that is currently being built by Codemagic, for pull request builds it is the hash of the source commit |
-| FCI_PULL_REQUEST         | `true`, if the current build is building a pull request, unset otherwise                                        |
+| FCI_PULL_REQUEST         | `true`, if the current build is building a pull request, `false` otherwise                                      |
 | FCI_PULL_REQUEST_NUMBER  | Set to Integer ID of the pull request for the Git provider (Bitbucket, Github etc) if the current build is building a pull request, unset otherwise|
 | FCI_CLONE_UNSHALLOW      | If set to `true`, performs a full clone of the repository instead of top 50 commits                             |
 | FCI_CLONE_DEPTH          | Specifies the clone depth which allows to decrease default fetching time when is set lower than 50              |


### PR DESCRIPTION
FCI_REPO_SLUG, FCI_PULL_REQUEST, FCI_PULL_REQUEST_NUMBER env vars are already in live added by me.
FCI_CLONE_DEPTH is already in live added by Armold.

FCI_BRANCH shows pr's source branch (not destination)