### PR TITLE
Update title

### DIFF
--- a/content/building/access-private-git-submodules.md
+++ b/content/building/access-private-git-submodules.md
@@ -1,6 +1,6 @@
 ---
 description: Access any private Git submodules or dependencies in Codemagic
-title: Accessing private repositories
+title: Accessing private dependencies and git submodules
 weight: 5
 ---
 


### PR DESCRIPTION
Current title of the documentation is misleading, because private dependencies are visible by default with OAuth authentication. We are trying to help developers access repositories outside of their repository that are not accessible by our OAuth scope. Hence rename title to accessing private dependencies and git submodules