### PR TITLE
use blue color for all links instead of cyan

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -266,9 +266,12 @@ body {
                 max-width: 100%;
             }
             a {
-              color: #158fdc;
+              color: $blue;
+              &:hover {
+                color: $blue-hover;
+              }
               code {
-                color: #158fdc;
+                color: $blue;
               }
             }
             figure {


### PR DESCRIPTION
currently only links in content are cyan, other links are blue on hover
![image](https://user-images.githubusercontent.com/17024977/93578976-9bae4c00-f9a6-11ea-8497-af0df7807465.png)