### PR TITLE
Add info about publishing to Firebase Hosting

### DIFF
--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -128,7 +128,7 @@ Android
     - name: Publish the app to Firebase App Distribution
       script: |
         apkPath=$(find build -name "*.apk" | head -1)
-
+    
         if [[ -z ${apkPath} ]]
         then
           echo "No apks were found, skip publishing to Firebase App Distribution"
@@ -142,7 +142,7 @@ iOS
     - name: Publish the app to Firebase App Distribution
       script: |
         ipaPath=$(find build -name "*.ipa" | head -1)
-
+    
         if [[ -z ${ipaPath} ]]
         then
           echo "No ipas were found, skip publishing to Firebase App Distribution"
@@ -227,3 +227,17 @@ And then export the filepath on the gradlew task
         cd android && ./gradlew appDistributionUploadRelease
 
 {{</notebox>}}
+
+### Publishing web applications to Firebase Hosting
+
+Publishing web applications to Firebase Hosting With Codemagic publishing to Firebase Hosting is a straight-forward process as the Firebase CLI is already pre-installed on our virtual machines. To get started, you will need to obtain your Firebase token. In order to do that, run `firebase login:ci` in your local terminal.
+
+After running the command, your default browser should prompt for authorization to your Firebase project - when access is granted, the necessary token will appear in your terminal. 
+
+The next step is to add your token to Codemagic. To properly set everything up, please [encrypt](https://github.com/codemagic-ci-cd/codemagic-docs/blob/master/content/building/encrypting) the token using Codemagic UI and set it under your environment variables with the name `FIREBASE_TOKEN`. Now all that is needed to publish to Firebase Hosting is to add the publishing step to your .yaml file
+
+    - name: Publish to Firebase Hosting
+      script: |
+        firebase deploy --token "$FIREBASE_TOKEN"
+
+Make sure to add the publishing step after the build step. After the build is finished, you can now find your application published to Firebase Hosting, it is also possible to retrieve the direct URL from the log output in the UI. Please note that before trying to publish to Firebase Hosting, you will have to set it up for your project locally. You can find more information in the official [documentation](https://firebase.google.com/docs/hosting/quickstart) for Firebase.

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -128,7 +128,6 @@ Android
     - name: Publish the app to Firebase App Distribution
       script: |
         apkPath=$(find build -name "*.apk" | head -1)
-    
         if [[ -z ${apkPath} ]]
         then
           echo "No apks were found, skip publishing to Firebase App Distribution"
@@ -142,7 +141,6 @@ iOS
     - name: Publish the app to Firebase App Distribution
       script: |
         ipaPath=$(find build -name "*.ipa" | head -1)
-    
         if [[ -z ${ipaPath} ]]
         then
           echo "No ipas were found, skip publishing to Firebase App Distribution"

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -234,13 +234,13 @@ Publishing web applications to Firebase Hosting With Codemagic publishing to Fir
 2. After running the command, your default browser should prompt for authorization to your Firebase project - when access is granted, the necessary token will appear in your terminal.
 3. Copy and [encrypt](https://github.com/codemagic-ci-cd/codemagic-docs/blob/master/content/building/encrypting) the token using the Codemagic UI.
 4. Add your encrypted token to your .yaml file by setting it under your environment variables with the name `FIREBASE_TOKEN`.
-5. Create a new script for publishing to Firebase Hosting in your scripts section of the .yaml after the build step
+5. Create a new script for publishing to Firebase Hosting in your scripts section of the .yaml file and add it right after the build step
 ```
     - name: Publish to Firebase Hosting
       script: |
         firebase deploy --token "$FIREBASE_TOKEN"
 ```
-When the build is successful, you can find your application published to Firebase Hosting. It is also possible to retrieve the direct URL from the log output in the UI in case of a successful build under the publishing script
+When the build is successful, you can see your application published to Firebase Hosting. You can find the direct URL to the deployed build also from the log output in Codemagic UI:
 ```
 ✔  Deploy complete!
 

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -234,11 +234,11 @@ Publishing web applications to Firebase Hosting With Codemagic publishing to Fir
 2. [Encrypt](https://github.com/codemagic-ci-cd/codemagic-docs/blob/master/content/building/encrypting) the token using the Codemagic UI.
 3. Add your encrypted token to your .yaml file by setting it under your environment variables with the name `FIREBASE_TOKEN`.
 4. Create a new script for publishing to Firebase Hosting in your scripts section of the .yaml after the build step
-
+```
     - name: Publish to Firebase Hosting
       script: |
         firebase deploy --token "$FIREBASE_TOKEN"
-
+```
 When the build is successful, you can find your application published to Firebase Hosting. It is also possible to retrieve the direct URL from the log output in the UI in case of a successful build under the publishing script:
 
 ```

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -226,16 +226,24 @@ And then export the filepath on the gradlew task
 
 {{</notebox>}}
 
-### Publishing web applications to Firebase Hosting
+## Publishing web applications to Firebase Hosting
 
-Publishing web applications to Firebase Hosting With Codemagic publishing to Firebase Hosting is a straight-forward process as the Firebase CLI is already pre-installed on our virtual machines. To get started, you will need to obtain your Firebase token. In order to do that, run `firebase login:ci` in your local terminal.
+Publishing web applications to Firebase Hosting With Codemagic publishing to Firebase Hosting is a straight-forward process as the Firebase CLI is already pre-installed on our virtual machines. Please note that before trying to publish to Firebase Hosting, you will have to set it up for your project locally. You can find more information in the official [documentation](https://firebase.google.com/docs/hosting/quickstart) for Firebase.
 
-After running the command, your default browser should prompt for authorization to your Firebase project - when access is granted, the necessary token will appear in your terminal. 
-
-The next step is to add your token to Codemagic. To properly set everything up, please [encrypt](https://github.com/codemagic-ci-cd/codemagic-docs/blob/master/content/building/encrypting) the token using Codemagic UI and set it under your environment variables with the name `FIREBASE_TOKEN`. Now all that is needed to publish to Firebase Hosting is to add the publishing step to your .yaml file
+1. To get started with adding Firebase Hosting to Codemagic, you will need to obtain your Firebase token. In order to do that, run `firebase login:ci` in your local terminal. After running the command, your default browser should prompt for authorization to your Firebase project - when access is granted, the necessary token will appear in your terminal.
+2. [Encrypt](https://github.com/codemagic-ci-cd/codemagic-docs/blob/master/content/building/encrypting) the token using the Codemagic UI.
+3. Add your encrypted token to your .yaml file by setting it under your environment variables with the name `FIREBASE_TOKEN`.
+4. Create a new script for publishing to Firebase Hosting in your scripts section of the .yaml after the build step
 
     - name: Publish to Firebase Hosting
       script: |
         firebase deploy --token "$FIREBASE_TOKEN"
 
-Make sure to add the publishing step after the build step. After the build is finished, you can now find your application published to Firebase Hosting, it is also possible to retrieve the direct URL from the log output in the UI. Please note that before trying to publish to Firebase Hosting, you will have to set it up for your project locally. You can find more information in the official [documentation](https://firebase.google.com/docs/hosting/quickstart) for Firebase.
+When the build is successful, you can find your application published to Firebase Hosting. It is also possible to retrieve the direct URL from the log output in the UI in case of a successful build under the publishing script:
+
+```
+✔  Deploy complete!
+
+Project Console: https://console.firebase.google.com/project/your-project/overview
+Hosting URL: https://your-project.web.app
+```

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -230,17 +230,17 @@ And then export the filepath on the gradlew task
 
 Publishing web applications to Firebase Hosting With Codemagic publishing to Firebase Hosting is a straight-forward process as the Firebase CLI is already pre-installed on our virtual machines. Please note that before trying to publish to Firebase Hosting, you will have to set it up for your project locally. You can find more information in the official [documentation](https://firebase.google.com/docs/hosting/quickstart) for Firebase.
 
-1. To get started with adding Firebase Hosting to Codemagic, you will need to obtain your Firebase token. In order to do that, run `firebase login:ci` in your local terminal. After running the command, your default browser should prompt for authorization to your Firebase project - when access is granted, the necessary token will appear in your terminal.
-2. [Encrypt](https://github.com/codemagic-ci-cd/codemagic-docs/blob/master/content/building/encrypting) the token using the Codemagic UI.
-3. Add your encrypted token to your .yaml file by setting it under your environment variables with the name `FIREBASE_TOKEN`.
-4. Create a new script for publishing to Firebase Hosting in your scripts section of the .yaml after the build step
+1. To get started with adding Firebase Hosting to Codemagic, you will need to obtain your Firebase token. In order to do that, run `firebase login:ci` in your local terminal. 
+2. After running the command, your default browser should prompt for authorization to your Firebase project - when access is granted, the necessary token will appear in your terminal.
+3. Copy and [encrypt](https://github.com/codemagic-ci-cd/codemagic-docs/blob/master/content/building/encrypting) the token using the Codemagic UI.
+4. Add your encrypted token to your .yaml file by setting it under your environment variables with the name `FIREBASE_TOKEN`.
+5. Create a new script for publishing to Firebase Hosting in your scripts section of the .yaml after the build step
 ```
     - name: Publish to Firebase Hosting
       script: |
         firebase deploy --token "$FIREBASE_TOKEN"
 ```
-When the build is successful, you can find your application published to Firebase Hosting. It is also possible to retrieve the direct URL from the log output in the UI in case of a successful build under the publishing script:
-
+When the build is successful, you can find your application published to Firebase Hosting. It is also possible to retrieve the direct URL from the log output in the UI in case of a successful build under the publishing script
 ```
 ✔  Deploy complete!
 


### PR DESCRIPTION
This pull request adds basic information on how to use Codemagic to publish web applications to Firebase Hosting. While trivial, there seem to be users who need confirmation that it works and help setting it up. 