### PR TITLE
Update signing-android.md

### DIFF
--- a/content/code-signing-yaml/signing-android.md
+++ b/content/code-signing-yaml/signing-android.md
@@ -23,7 +23,7 @@ This example shows how to set up code signing using Gradle.
               if (System.getenv()["CI"]) { // CI=true is exported by Codemagic
                   storeFile file(System.getenv()["CM_KEYSTORE_PATH"])
                   storePassword System.getenv()["CM_KEYSTORE_PASSWORD"]
-                  keyAlias System.getenv()["CM_KEY_ALIAS"]
+                  keyAlias System.getenv()["CM_KEY_ALIAS_USERNAME"]
                   keyPassword System.getenv()["CM_KEY_ALIAS_PASSWORD"]
               } else {
                   storeFile file("/path/to/local/myreleasekey.keystore")


### PR DESCRIPTION
When we export .yaml workflows that have Android code signing enabled, we export the alias as CM_KEY_ALIAS_USERNAME, but we recommend to use CM_KEY_ALIAS in documentation when setting up gradle, thus if users are exporting the .yaml, then this creates issues (and we're also telling them to set CM_KEY_ALIAS_USERNAME below).