### PR TITLE
Document public dashboards

### DIFF
--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -1,7 +1,7 @@
 ---
-title: Publishing
+title: Publishing and deployment
 description: How to set up publishing and build status notifications
-weight: 3
+weight: 1
 aliases:
     - '../yaml/distribution'
 ---

--- a/content/publishing-yaml/public-dashboards.md
+++ b/content/publishing-yaml/public-dashboards.md
@@ -1,0 +1,34 @@
+---
+title: Public dashboards
+description: Use public links to distribute builds and artifacts
+weight: 2
+aliases:
+---
+
+Public dashboards make it possible for teams to share the list of team's builds, release notes (if passed) and build artifacts with people outside Codemagic using a public link (build logs will not be exposed). This is a convenient option for distributing builds to testers or sharing build artifacts with stakeholders. 
+
+{{<notebox>}}
+The public dashboards feature is available for teams only. It is not possible to create public dashboards for apps on personal accounts.
+{{</notebox>}}
+
+## Enabling public dashboards
+
+To use public dashboards, teams owners will have to enable the feature in team settings. 
+
+In team settings, expand the **Public dashboards** section and click **Enable sharing**. This will allow any team member to create public links to share the build dashboards they create. 
+
+Public dashboards can be disabled anytime by clicking **Disable sharing**.
+
+## Creating and sharing a build dashboard
+
+Open the **Builds** page via the left sidebar and use the **team**, **application**, **workflow** and **branch** filters to create a build dashboard. Then click **Share dashboard** at the top of the page to generate a public link to it. A popup with the generated link will appear and you can copy the link to clipboard. The generated link will be also saved to the **Public dashboards** section in team settings.
+
+{{<notebox>}}
+Please note that anyone with the public link can access the build dashboard and download build artifacts.
+{{</notebox>}}
+
+## Managing links
+
+All generated links to public dashboards are listed in the **Public dashboards** section in team settings. 
+
+Links can be revoked by deleting them or when a team owner disables sharing by clicking **Disable sharing**. When sharing is reenabled, the available links become active again.

--- a/content/publishing-yaml/public-dashboards.md
+++ b/content/publishing-yaml/public-dashboards.md
@@ -13,15 +13,15 @@ The public dashboards feature is available for teams only. It is not possible to
 
 ## Enabling public dashboards
 
-To use public dashboards, teams owners will have to enable the feature in team settings. 
+To use public dashboards, team owners will have to enable the feature in team settings. 
 
-In team settings, expand the **Public dashboards** section and click **Enable sharing**. This will allow any team member to create public links to share the build dashboards they create. 
+In team settings, expand the **Public dashboards** section and click **Enable sharing**. This will allow any team member to create dashboards and generate public links to share them.
 
 Public dashboards can be disabled anytime by clicking **Disable sharing**.
 
 ## Creating and sharing a build dashboard
 
-Open the **Builds** page via the left sidebar and use the **team**, **application**, **workflow** and **branch** filters to create a build dashboard. Then click **Share dashboard** at the top of the page to generate a public link to it. A popup with the generated link will appear and you can copy the link to clipboard. The generated link will be also saved to the **Public dashboards** section in team settings.
+Open the **Builds** page via the navigation bar and use the **team**, **application**, **workflow** and **branch** filters on the left sidebar to create a build dashboard. Then click **Share dashboard** at the top of the page to generate a public link to it. A popup with the generated link will appear and you can copy the link to clipboard. The generated link will be also saved to the **Public dashboards** section in team settings.
 
 {{<notebox>}}
 Please note that anyone with the public link can access the build dashboard and download build artifacts.
@@ -31,4 +31,4 @@ Please note that anyone with the public link can access the build dashboard and 
 
 All generated links to public dashboards are listed in the **Public dashboards** section in team settings. 
 
-Links can be revoked by deleting them or when a team owner disables sharing by clicking **Disable sharing**. When sharing is reenabled, the available links become active again.
+Links can be revoked by deleting them or when a team owner disables sharing by clicking **Disable sharing**. When sharing is re-enabled, the available links become active again.

--- a/content/teams/teams.md
+++ b/content/teams/teams.md
@@ -54,6 +54,10 @@ Owners can upgrade members to owners by clicking on the three dots next to their
 
 Users that have triggered builds can be invited to the team by clicking **Add to team** on the email address in the list of users.
 
+## Public dashboards
+
+The public dashboards feature makes it possible to share team's builds and build artifacts via a public link. Read more about this feature [here](./public-dashboards).
+
 ## Managing team integrations
 
 In Team integrations, it is possible to set up integrations to be used with team apps.


### PR DESCRIPTION
- Added a new page about public dashboards to the Publishing category
- Mentioned the feature in the documentation for teams