### PR TITLE
[Docs - Getting Started] Remove branch_patterns as it is in different level

### DIFF
--- a/content/getting-started/yaml.md
+++ b/content/getting-started/yaml.md
@@ -104,7 +104,6 @@ workflows:
     environment:
     cache:
     triggering:
-    branch_patterns:
     scripts:
     artifacts:
     publishing:


### PR DESCRIPTION
## Issue
The `branch_patterns` was defined at the same level as the `triggering`. It should be under the `triggering` as a **sub-property**. 
## Fix
Removed the `branch_patterns` property as here only a brief of the properties at the same level (under `my-workflow`) are shown.