### PR TITLE
Change default build number to 1 instead of 0

### DIFF
--- a/content/getting-started/building-a-react-native-app.md
+++ b/content/getting-started/building-a-react-native-app.md
@@ -168,7 +168,7 @@ Incrementing the version code can be done as follows:
     android {
         ...
         
-        def appVersionCode = Integer.valueOf(System.env.BUILD_NUMBER ?: 0)
+        def appVersionCode = Integer.valueOf(System.env.BUILD_NUMBER ?: 1)
         defaultConfig {
             ...
             versionCode appVersionCode


### PR DESCRIPTION
Building my android project locally caused a failure that the versionCode must be a positive integer greater than 0.