### PR TITLE
Update how to publish to private channels in Slack

### DIFF
--- a/content/publishing/email-and-slack-notifications.md
+++ b/content/publishing/email-and-slack-notifications.md
@@ -26,7 +26,7 @@ In order to set up publishing to Slack, you first need to connect the Slack work
 
 Once your Slack workspace is connected, you can enable Slack publishing and select a channel for publishing in **App settings > Publish > Slack** when using the UI configuration.
 
-in order to publish to private channels you need to invite Codemagic app to the channels, otherwise the app does not have access to private channels. To invite Codemagic app to private channels write `@codemagic` in the channel. If you are in the codemagic web app, refresh the page and the new channel will become available in the dropdown menu.
+In order to publish to **private channels**, you need to invite Codemagic app to the channels, otherwise the app does not have access to private channels. To invite Codemagic app to private channels, write `@codemagic` in the channel. If you are in the Codemagic web app, refresh the page and the new channel will become available in the dropdown menu.
 
 If the build finishes successfully, release notes (if passed) and the generated artifacts will be published to the specified channel.
 

--- a/content/publishing/email-and-slack-notifications.md
+++ b/content/publishing/email-and-slack-notifications.md
@@ -26,6 +26,8 @@ In order to set up publishing to Slack, you first need to connect the Slack work
 
 Once your Slack workspace is connected, you can enable Slack publishing and select a channel for publishing in **App settings > Publish > Slack** when using the UI configuration.
 
+in order to publish to private channels you need to invite Codemagic app to the channels, otherwise the app does not have access to private channels. To invite Codemagic app to private channels write `@codemagic` in the channel. If you are in the codemagic web app, refresh the page and the new channel will become available in the dropdown menu.
+
 If the build finishes successfully, release notes (if passed) and the generated artifacts will be published to the specified channel.
 
 If the build fails, a link to the build logs is published. Check **Publish artifacts even if tests fail** to publish artifacts even when one or more tests fail. If the option is unchecked, generated artifacts (if any) will be attached to successful builds only.


### PR DESCRIPTION
With new granular permissions Codemagic Slack app cannot see or publish to private slack channels, but it is possible once the app has been added to the private channel. This PR improves docs to cover how to publish to private Slack channels. 