### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Development requires [Hugo static site generator](https://gohugo.io). It can be 
 brew install hugo
 ```
 
-Note, that Hugo extended v0.77.0 is used in production. This Hugo version can be downloaded from [releases page](https://github.com/gohugoio/hugo/releases/tag/v0.77.0).
+Note that Hugo extended v0.77.0 is used in production. This Hugo version can be downloaded from [releases page](https://github.com/gohugoio/hugo/releases/tag/v0.77.0).
 
 Windows users can install [Chocolatey](https://chocolatey.org/install). After that Hugo can be installed with
 

--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,7 @@ Please follow the format of existing issues for consistency.
 
 ## Development
 
-Development requires [Hugo static site generator](https://gohugo.io) v077.0 from [releases page](https://github.com/gohugoio/hugo/releases) or with Homebrew for Linux and macOS users.
-
-```
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/79894aee20a146d6cf7db7b4a362e7d491f499a1/Formula/hugo.rb
-```
+Development requires [Hugo static site generator](https://gohugo.io) hugo_extended v0.77.0 from [releases page](https://github.com/gohugoio/hugo/releases).
 
 Windows users can install [Chocolatey](https://chocolatey.org/install). After that Hugo can be installed with
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,13 @@ Please follow the format of existing issues for consistency.
 
 ## Development
 
-Development requires [Hugo static site generator](https://gohugo.io) hugo_extended v0.77.0 from [releases page](https://github.com/gohugoio/hugo/releases).
+Development requires [Hugo static site generator](https://gohugo.io). It can be installed with Homebrew for Linux and macOS users
+ 
+```
+brew install hugo
+```
+
+Note, that Hugo extended v0.77.0 is used in production. This Hugo version can be downloaded from [releases page](https://github.com/gohugoio/hugo/releases/tag/v0.77.0).
 
 Windows users can install [Chocolatey](https://chocolatey.org/install). After that Hugo can be installed with
 


### PR DESCRIPTION
Installation command
```
brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/79894aee20a146d6cf7db7b4a362e7d491f499a1/Formula/hugo.rb
```
fails with
```
Invalid usage: Installation of hugo from a GitHub commit URL is unsupported! `brew extract hugo` to a stable tap on GitHub instead. (UsageError)
```