### PR TITLE
add google play track env var

### DIFF
--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -70,7 +70,7 @@ publishing:
 
 ### Google Play
 
-Codemagic enables you to automatically publish your app to the `internal`, `alpha`, `beta` and `production` tracks on Google Play. In order to do so, you will need to set up a service account in Google Play Console and add the `JSON` key file to your Codemagic configuration file, see how to [set up a service account](../knowledge-base/google-play-api/).
+Codemagic enables you to automatically publish your app to the `internal`, `alpha`, `beta` and `production` tracks on Google Play. In order to do so, you will need to set up a service account in Google Play Console and add the `JSON` key file to your Codemagic configuration file, see how to [set up a service account](../knowledge-base/google-play-api/). The proper way to add your keys to `codemagic.yaml` is to [encrypt](../building/encrypting) the contents of the key file and add the encrypted value into the configuration file.
 
 If your application supports [in-app updates](https://developer.android.com/guide/playcore/in-app-updates) Codemagic allows setting the update priority. Otherwise, `in_app_update_priority` can be omitted or set to `0`.
 
@@ -85,10 +85,8 @@ publishing:
     rollout_fraction: 0.25            # Rollout fraction (set only if releasing to a fraction of users): value between (0, 1)
 ```
 
-You can override the specified in publishing track with environment variable `GOOGLE_PLAY_TRACK`.
-
 {{<notebox>}}
-The proper way to add your keys in `codemagic.yaml` is to copy the contents of the key file and [encrypt](../building/encrypting) it. Then add the encrypted value into the configuration file.
+You can override the publishing track specified in the configuration file using the environment variable `GOOGLE_PLAY_TRACK`. This is useful if you're starting your builds via [Codemagic API](../rest-api/overview/) and want to build different configurations without editing the configuration file.
 {{</notebox>}}
 
 ### App Store Connect

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -85,6 +85,8 @@ publishing:
     rollout_fraction: 0.25            # Rollout fraction (set only if releasing to a fraction of users): value between (0, 1)
 ```
 
+You can override the specified in publishing track with environment variable `GOOGLE_PLAY_TRACK`.
+
 {{<notebox>}}
 The proper way to add your keys in `codemagic.yaml` is to copy the contents of the key file and [encrypt](../building/encrypting) it. Then add the encrypted value into the configuration file.
 {{</notebox>}}


### PR DESCRIPTION
This is the env var which we respect, but it's not reflected in docs. Probably may be useful to somebody. Please rephrase in any way needed.