### PR TITLE
Update docs.md

### DIFF
--- a/content/specs/versions.md
+++ b/content/specs/versions.md
@@ -51,7 +51,7 @@ weight: 2
 
 ## Xcode 11.7 (11E801a)
 
-This is the Xcode version used by default when you select `latest` in build settings. Other available versions are listed [here](#other-xcode-versions).
+This is the Xcode version used by default when you select `11.7` in build settings in the UI for Flutter apps or set Xcode version to `11.7` in your codemagic.yaml file. Other available versions are listed [here](#other-xcode-versions).
 
 Xcode path: `/Applications/Xcode-11.7.app`
 


### PR DESCRIPTION
using latest version does not point to 11.7, because it is not the latest and .yaml users cannot select the version in build settings. You need to fix the version in order to use 11.7. Changes to docs are made accordingly.