### PR TITLE
Add automatic ios code signing youtube video

### DIFF
--- a/content/code-signing-yaml/signing-ios.md
+++ b/content/code-signing-yaml/signing-ios.md
@@ -21,6 +21,8 @@ Under the hood, we use [Codemagic CLI tools](https://github.com/codemagic-ci-cd/
 
 ## Automatic code signing
 
+{{< youtube 2kLi7Fe7q-0 >}}
+
 In order to use automatic code signing and have Codemagic manage signing certificates and provisioning profiles on your behalf, you need to configure API access to App Store Connect.
 
 ### Creating the App Store Connect API key

--- a/content/code-signing/ios-code-signing.md
+++ b/content/code-signing/ios-code-signing.md
@@ -43,6 +43,8 @@ In short, the purpose of the different provisioning profiles is the following:
 
 ## Automatic code signing
 
+{{< youtube aBDx6BKFXIA >}}
+
 Codemagic makes automatic code signing possible by connecting to [App Store Connect via its API](https://developer.apple.com/app-store-connect/api/) for creating and managing your code signing certificates and provisioning profiles. It is possible to set up several code signing identities and use different code signing settings per workflow.
 
 The following sections describe how to set up automatic code signing for builds configured in the UI. If you're building with `codemagic.yaml`, please refer [here](../code-signing-yaml/signing-ios).


### PR DESCRIPTION
Hugo has a nice [youtube shortcut](https://gohugo.io/content-management/shortcodes/#youtube) for embedding videos.

![Screen Shot 2021-03-17 at 10 45 08 AM](https://user-images.githubusercontent.com/431915/111439641-3eeddd00-870e-11eb-846a-f4593e71211c.png)
![Screen Shot 2021-03-17 at 10 52 03 AM](https://user-images.githubusercontent.com/431915/111440376-f1be3b00-870e-11eb-9a85-4dc295023225.png)
