### PR TITLE
update machine specifications with java and emulators, and allow to choose java

### DIFF
--- a/content/flutter/custom-scripts.md
+++ b/content/flutter/custom-scripts.md
@@ -8,7 +8,7 @@ aliases:
 
 You can customize the Codemagic workflow by running custom scripts before and after the default build steps.
 
-In the Flutter workflow editor, the spots for injecting custom scripts are marked by **'+'** signs between the sections. Click on **'+'** to expand the section and add your script in the appropriate section. You can run custom scripts in post-clone, pre-test, post-test, pre-build, post-build, pre-publish and post-publish phases. The scripts can be run in any language, simply define the language with a shebang line. For example, `#!/usr/bin/env python`.
+In the Flutter workflow editor, the spots for injecting custom scripts are marked by **'+'** signs between the sections. Click on **'+'** to expand the section and add your script in the appropriate section. You can run custom scripts in post-clone, pre-test, post-test, pre-build, post-build, pre-publish and post-publish phases. The scripts can be run in any language, simply define the language with a shebang line. For example, `#!/usr/bin/env python3`.
 
 {{<notebox>}}
 Please note that custom scripts are always executed from the absolute path to the cloned repository which is located at `/Users/builder/clone` and can also be accessed using the environment variable `FCI_BUILD_DIR`. If your project is not in the repository root and you want to access it from a script, you will need to move to the needed directory inside the script.

--- a/content/getting-started/yaml.md
+++ b/content/getting-started/yaml.md
@@ -134,13 +134,13 @@ environment:
   vars:             # Define your environment variables here
     PUBLIC_ENV_VAR: "value here"
     SECRET_ENV_VAR: Encrypted(...)
-    
+
     # Android code signing
     FCI_KEYSTORE: Encrypted(...)
     FCI_KEYSTORE_PASSWORD: Encrypted(...)
     FCI_KEY_PASSWORD: Encrypted(...)
     FCI_KEY_ALIAS: Encrypted(...)
-    
+
     # iOS automatic code signing
     APP_STORE_CONNECT_ISSUER_ID: Encrypted(...)
     APP_STORE_CONNECT_KEY_IDENTIFIER: Encrypted(...)
@@ -166,10 +166,15 @@ environment:
   node: 12.14.0     # Define default, latest, current, lts, carbon (or another stream), nightly or version
   npm: 6.13.7       # Define default, latest, next, lts or version
   ndk: r21d         # Define default or revision (e.g. r19c)
+  java: 1.8         # Define default, or platform version (e.g. 11). The default platform version is 1.8
 ```
 
 {{<notebox>}}
-See the default software versions on Codemagic build machines [here](../releases-and-versions/versions/).
+See the default software versions on Codemagic build machines:
+- [macOS build machine specification (Xcode 11.x)](../releases-and-versions/versions/)
+- [macOS build machine specification (Xcode 12.0-12.4)](../releases-and-versions/versions2/)
+- [macOS build machine specification (Xcode 12.5+)](../releases-and-versions/versions3/)
+- [Linux build machine specification](../releases-and-versions/versions-linux/)
 {{</notebox>}}
 
 ### Cache

--- a/content/specs/versions-linux.md
+++ b/content/specs/versions-linux.md
@@ -44,6 +44,18 @@ weight: 5
 - yq `3.3.2`
 - zip
 
+## Android emulators
+
+- **emulator**
+
+    - Device: `pixel_4 (Google)`
+    - Path: `/home/builder/.android/avd/emulator.avd`
+    - Target: `Google Play (Google Inc.)`
+    - Based on: `Android 10.0 (Q)`
+    - Tag/API: `google_apis_playstore/x86`
+    - Skin: `pixel_4`
+    - Sdcard: `512M`
+
 ## Java versions
 
 - **15**: version `15-ea (2020-09-15)`, OpenJDK Runtime Environment

--- a/content/specs/versions-linux.md
+++ b/content/specs/versions-linux.md
@@ -44,6 +44,12 @@ weight: 5
 - yq `3.3.2`
 - zip
 
+## Java versions
+
+- **15**: version `15-ea (2020-09-15)`, OpenJDK Runtime Environment
+- **11**: version `11.0.10 (2021-01-19)`, OpenJDK Runtime Environment
+- **1.8**: version `1.8.0_282`, OpenJDK Runtime Environment
+
 ## Android Studio 4.1.2 (201.8743.12.41.7042882)
 
 Android Studio path: `~/programs/android-studio`

--- a/content/specs/versions.md
+++ b/content/specs/versions.md
@@ -49,6 +49,24 @@ weight: 4
 - yq
 - zip
 
+## Android emulators
+
+- **emulator**
+
+    - Device: `pixel_2 (Google)`
+    - Path: `/Users/builder/.android/avd/emulator.avd`
+    - Target: `Google APIs (Google Inc.)`
+    - Based on: `Android 9.0 (Pie)`
+    - Tag/API: `google_apis/x86`
+    - Skin: `pixel_2`
+    - Sdcard: `512M`
+## Java versions
+
+- **14**: version `14.0.2`, JVM `OpenJDK 14.0.2`
+- **9**: version `9.0.4`, JVM `OpenJDK 9.0.4`
+- **1.8**: version `1.8.0_202`, JVM `Java SE 8`
+- **1.7**: version `1.7.0_272`, JVM `Zulu 7.40.0.15`
+
 ## Xcode 11.7 (11E801a)
 
 This is the Xcode version used by default when you select `11.7` in build settings in the workflow editor for Flutter apps or set Xcode version to `11.7` in your codemagic.yaml file. Other available versions are listed [here](#other-xcode-versions).

--- a/content/specs/versions2.md
+++ b/content/specs/versions2.md
@@ -1,6 +1,6 @@
 ---
 description: A list of tools available out-of-the-box on Codemagic build machines
-title: macOS build machine specification (Xcode 12+)
+title: macOS build machine specification (Xcode 12.0 - 12.4)
 aliases:
   - '../releases-and-versions/versions2'
 weight: 3

--- a/content/specs/versions2.md
+++ b/content/specs/versions2.md
@@ -49,6 +49,24 @@ weight: 3
 - yq
 - zip
 
+## Android emulators
+
+- **emulator**
+
+    - Device: `pixel_2 (Google)`
+    - Path: `/Users/builder/.android/avd/emulator.avd`
+    - Target: `Google APIs (Google Inc.)`
+    - Based on: `Android 10.0 (Q)`
+    - Tag/API: `google_apis/x86`
+    - Skin: `pixel_2`
+    - Sdcard: `512M`
+## Java versions
+
+- **15**: version `15.0.1`, JVM `Zulu 15.28.51`
+- **11**: version `11.0.9.1`, JVM `Zulu 11.43.55`
+- **1.8**: version `1.8.0_275`, JVM `Zulu 8.50.0.51`
+- **1.7**: version `1.7.0_285`, JVM `Zulu 7.42.0.51`
+
 ## Xcode 12.4 (12D4e)
 
 This is the Xcode version used by default when you select `latest` in build settings. Other available versions are listed [here](#other-xcode-versions).

--- a/content/specs/versions3.md
+++ b/content/specs/versions3.md
@@ -49,6 +49,24 @@ weight: 2
 - yq
 - zip
 
+## Android emulators
+
+- **emulator**
+
+    - Device: `pixel_3a (Google)`
+    - Path: `/Users/builder/.android/avd/emulator.avd`
+    - Target: `Google Play (Google Inc.)`
+    - Based on: `Android 10.0 (Q)`
+    - Tag/API: `google_apis_playstore/x86`
+    - Skin: `pixel_3a`
+    - Sdcard: `512M`
+
+## Java versions
+
+- **15**: version `15.0.2`, JVM `Zulu 15.29.15`
+- **11**: version `11.0.10`, JVM `Zulu 11.45.27`
+- **1.8**: version `1.8.0_282`, JVM `Zulu 8.52.0.23`
+
 ## Xcode 12.5 (12E5244e)
 
 This is the Xcode version used when you select `12.5` in build settings. Other available versions are listed [here](#other-xcode-versions).


### PR DESCRIPTION
I find it strange to have 12+ and 12.5+ names for machines since 12+ semantically includes 12.5+. Better to put the range there.

Also previous `See the default software versions on Codemagic build machines` pointed to macos with xcode 11, which could be a bin confusing since the default versions there are different, which includes such important soft as cocoapods, dart, docker etc. So better to list all the machines.

Added java and emulators info manually to not wait for base image updates, especially since we don't do base image update for older xcode machines.

Changed `#!/usr/bin/env python` to `#!/usr/bin/env python3` since on not xcode 12.5+ machines it resolves to python 2.7