### PR TITLE
Tweak example for FCI_CERTIFICATE decoding

### DIFF
--- a/content/code-signing-yaml/signing-ios.md
+++ b/content/code-signing-yaml/signing-ios.md
@@ -128,10 +128,13 @@ scripts:
   - name: Set up signing certificate
     script: |
       echo $FCI_CERTIFICATE | base64 --decode > /tmp/certificate.p12
-      # when using a password-protected certificate
-      keychain add-certificates --certificate /tmp/certificate.p12 --certificate-password $FCI_CERTIFICATE_PASSWORD
-      # when using a certificate that is not password-protected
-      keychain add-certificates --certificate /tmp/certificate.p12
+      if [ "$FCI_CERTIFICATE_PASSWORD" = "" ]; then
+        # when using a certificate that is not password-protected
+        keychain add-certificates --certificate /tmp/certificate.p12
+      else
+        # when using a password-protected certificate
+        keychain add-certificates --certificate /tmp/certificate.p12 --certificate-password $FCI_CERTIFICATE_PASSWORD
+      fi
   - name: Set up code signing settings on Xcode project
     script: xcode-project use-profiles
   ... your build commands

--- a/content/code-signing-yaml/signing-ios.md
+++ b/content/code-signing-yaml/signing-ios.md
@@ -128,7 +128,7 @@ scripts:
   - name: Set up signing certificate
     script: |
       echo $FCI_CERTIFICATE | base64 --decode > /tmp/certificate.p12
-      if [ "$FCI_CERTIFICATE_PASSWORD" = "" ]; then
+      if [ -z ${FCI_CERTIFICATE_PASSWORD+x} ]; then
         # when using a certificate that is not password-protected
         keychain add-certificates --certificate /tmp/certificate.p12
       else


### PR DESCRIPTION
This makes the code snippet slightly more flexible / ready to execute, such that people can have some certs with passphrases, and some without.