### PR TITLE
React Native link to GitHub project

### DIFF
--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -1,5 +1,0 @@
-{{ $id := .Get 0 }}
-
-<div class="github-embed-container">
-  <iframe src="{{ $id }}" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
-</div>

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -1,0 +1,5 @@
+{{ $id := .Get 0 }}
+
+<div class="github-embed-container">
+  <iframe src="{{ $id }}" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+</div>


### PR DESCRIPTION
Update to the React Native documentation so it links to the React Native demo project on GitHub. 