### PR TITLE
Add links to sample projects in codemagic.yaml getting started guides.

### DIFF
--- a/content/getting-started/building-a-flutter-app.md
+++ b/content/getting-started/building-a-flutter-app.md
@@ -47,6 +47,10 @@ The YAML feature currently has the following **limitations**:
 
 ## Android builds
 
+{{<notebox>}}
+You can find an up-to-date codemagic.yaml Flutter Android workflow in [Codemagic Sample Projects](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/flutter/flutter-yaml-demo-project/codemagic.yaml#L2).
+{{</notebox>}}
+
 Set up local properties
 
 ```yaml
@@ -80,6 +84,10 @@ Codemagic uses the [android-app-bundle](https://github.com/codemagic-ci-cd/cli-t
 {{</notebox>}}
 
 ## iOS builds
+
+{{<notebox>}}
+You can find an up-to-date codemagic.yaml Flutter iOS workflow in [Codemagic Sample Projects](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/flutter/flutter-yaml-demo-project/codemagic.yaml#L72).
+{{</notebox>}}
 
 ### Building an unsigned application .app
 

--- a/content/getting-started/building-a-native-android-app.md
+++ b/content/getting-started/building-a-native-android-app.md
@@ -43,6 +43,10 @@ To test, code sign and publish an Android app:
 
 ## Android workflow example
 
+{{<notebox>}}
+You can find an up-to-date codemagic.yaml Android workflow in [Codemagic Sample Projects](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/android/android-espresso-demo-project/codemagic.yaml).
+{{</notebox>}}
+
 The following example shows how to set up a workflow that builds your app and publishes to a Google Play internal track.
 
 ```yaml

--- a/content/getting-started/building-a-native-ios-app.md
+++ b/content/getting-started/building-a-native-ios-app.md
@@ -87,6 +87,10 @@ To test, code sign and publish an iOS app:
 
 ## iOS workflow example
 
+{{<notebox>}}
+You can find an up-to-date codemagic.yaml iOS workflow in Codemagic Sample Projects for [automatic code signing](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/ios/ios-automatic-code-signing-demo-project/codemagic.yaml) and [manual code signing](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/ios/ios-manual-code-signing-demo-project/codemagic.yaml).
+{{</notebox>}}
+
 The following example shows a workflow that can be used to publish your iOS app to App Store Connect.
 
 ```yaml

--- a/content/getting-started/building-a-react-native-app.md
+++ b/content/getting-started/building-a-react-native-app.md
@@ -28,6 +28,10 @@ Note that you need to set up a [webhook](../building/webhooks) for automatic bui
 
 ## Android
 
+{{<notebox>}}
+You can find an up-to-date codemagic.yaml React Native Android workflow in [Codemagic Sample Projects](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/react-native/react-native-demo-project/codemagic.yaml#L5).
+{{</notebox>}}
+
 Set up local properties
 
 ```yaml
@@ -43,8 +47,10 @@ Building an Android application:
 ## iOS
 
 {{<notebox>}}
-Codemagic uses the [xcode-project](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/xcode-project/README.md#xcode-project) to prepare iOS application code signing properties for build.
+You can find an up-to-date codemagic.yaml React Native iOS workflow in [Codemagic Sample Projects](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/react-native/react-native-demo-project/codemagic.yaml#L72).
 {{</notebox>}}
+
+Codemagic uses the [xcode-project](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/xcode-project/README.md#xcode-project) to prepare iOS application code signing properties for build.
 
 Script for building an iOS application:
 
@@ -52,7 +58,7 @@ Script for building an iOS application:
 - xcode-project build-ipa --workspace "ios/MyReact.xcworkspace" --scheme "MyReact"
 ```
 
-{{<notebox>}}Read more about different schemes in [Apple documentation](https://help.apple.com/xcode/mac/current/#/dev0bee46f46).{{</notebox>}} 
+Read more about different schemes in [Apple documentation](https://help.apple.com/xcode/mac/current/#/dev0bee46f46). 
 
 ## Testing, code signing and publishing
 
@@ -61,16 +67,6 @@ To test and publish a React Native app:
 * The code for testing a React Native app also goes under `scripts`, before build commands. An example for testing a React Naive app can be found [here](../testing-yaml/testing/#react-native-unit-test).
 * All iOS and Android applications need to be signed before release. See how to set up [iOS code signing](../code-signing-yaml/signing-ios) and [Android code signing](../code-signing-yaml/signing-android).
 * All generated artifacts can be published to external services. The available integrations currently are email, Slack and Google Play. It is also possible to publish elsewhere with custom scripts (e.g. Firebase App Distribution). Script examples for all of them are available [here](../publishing-yaml/distribution/#publishing).
-
-## iOS and Android workflow examples
-
-Please refer to the React Native demo project on GitHub:
-
-[https://github.com/codemagic-ci-cd/react-native-demo-project](https://github.com/codemagic-ci-cd/react-native-demo-project)
-
-This shows how to configure the **codemagic.yaml** so you can build and publish your **iOS** app to **App Store Connect**.
-
-It also contains a workflow that shows how to build and publish your **Android** app to a **Google Play** internal track.
 
 ## Build versioning your React Native app
 

--- a/content/getting-started/building-an-ionic-app.md
+++ b/content/getting-started/building-an-ionic-app.md
@@ -36,6 +36,10 @@ To test, code sign and publish Ionic Android and iOS apps:
 
 ## Android Ionic Capacitor workflow example
 
+{{<notebox>}}
+You can find an up-to-date codemagic.yaml Ionic Android workflow in [Codemagic Sample Projects](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/ionic/ionic-capacitor-demo-project/codemagic.yaml#L95).
+{{</notebox>}}
+
 The following example shows how to set up a workflow that builds your **Ionic Capacitor** Android app and publishes to a Google Play internal track.
 
 ```yaml
@@ -183,6 +187,10 @@ workflows:
 ```
 
 ## iOS Ionic Capacitor workflow example
+
+{{<notebox>}}
+You can find an up-to-date codemagic.yaml Ionic iOS workflow in [Codemagic Sample Projects](https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/ionic/ionic-capacitor-demo-project/codemagic.yaml#L2).
+{{</notebox>}}
 
 The following example shows a workflow that can be used to publish your **Ionic Capacitor** iOS app to App Store Connect.
 


### PR DESCRIPTION
As a V1 of linking docs and sample projects, I've added links to the github repositories from each codemagic.yaml starter file workflow example.

<img width="747" alt="Screen Shot 2021-04-22 at 17 56 38" src="https://user-images.githubusercontent.com/431915/115737044-75191f00-a394-11eb-9c0b-c6115d569286.png">
<img width="747" alt="Screen Shot 2021-04-22 at 17 56 52" src="https://user-images.githubusercontent.com/431915/115737049-777b7900-a394-11eb-9325-903693ec8008.png">
<img width="747" alt="Screen Shot 2021-04-22 at 17 57 12" src="https://user-images.githubusercontent.com/431915/115737055-78140f80-a394-11eb-9a51-8bab60677cc3.png">
<img width="747" alt="Screen Shot 2021-04-22 at 17 57 23" src="https://user-images.githubusercontent.com/431915/115737059-78aca600-a394-11eb-8b4f-b725b4a44afb.png">
<img width="747" alt="Screen Shot 2021-04-22 at 17 57 33" src="https://user-images.githubusercontent.com/431915/115737063-79453c80-a394-11eb-8c74-d971e3673901.png">
<img width="747" alt="Screen Shot 2021-04-22 at 17 57 44" src="https://user-images.githubusercontent.com/431915/115737067-79ddd300-a394-11eb-9dfc-2e9ab9a4e11c.png">
<img width="747" alt="Screen Shot 2021-04-22 at 17 57 58" src="https://user-images.githubusercontent.com/431915/115737072-7b0f0000-a394-11eb-9ed8-7fce1bc0fa88.png">
<img width="747" alt="Screen Shot 2021-04-22 at 17 58 05" src="https://user-images.githubusercontent.com/431915/115737077-7ba79680-a394-11eb-93b0-15e803233d3f.png">
