### PR TITLE
Android sdk path updates

### DIFF
--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -4,12 +4,12 @@ title: Environment variables
 weight: 2
 ---
 
-Environment variables are useful for storing information that you do not want to store in the repository, such as your credentials or workflow-specific data. In addition, you can make use of a number of read-only environment variables that Codemagic exports to customize your builds. 
+Environment variables are useful for storing information that you do not want to store in the repository, such as your credentials or workflow-specific data. In addition, you can make use of a number of read-only environment variables that Codemagic exports to customize your builds.
 
 {{<notebox>}}
-You can add evironment variables in the [environment](../getting-started/yaml/#environment) section of the `codemagic.yaml` confguration file or in the [Environment variables](../flutter/env-variables/) section in the Flutter workflow editor. 
+You can add evironment variables in the [environment](../getting-started/yaml/#environment) section of the `codemagic.yaml` confguration file or in the [Environment variables](../flutter/env-variables/) section in the Flutter workflow editor.
 
-See how to [encrypt sensitive information](./encrypting) in Codemagic. 
+See how to [encrypt sensitive information](./encrypting) in Codemagic.
 {{</notebox>}}
 
 ## Codemagic read-only environment variables
@@ -22,14 +22,16 @@ set -ex
 printenv
 ```
 
-Here is the list of Codemagic read-only environment variables that may be useful in your build configuration.
+Here you'll find some of the read-only environment variables explained.
 
 | **Environment variable** | **Value**                                                                                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ANDROID_SDK_ROOT         | Absolute path to Android SDK and tools                                                                                                                          |
 | CI                       | true                                                                                                                                                            |
 | CONTINUOUS_INTEGRATION   | true                                                                                                                                                            |
 | BUILD_NUMBER             | Number of the build for this project in Codemagic for the given workflow                                                                                        |
 | PROJECT_BUILD_NUMBER     | Number of the build for this project in Codemagic                                                                                                               |
+| FLUTTER_ROOT             | Absolute path to Flutter SDK                                                                                                                                    |
 | FCI_BRANCH               | The current branch being built, for pull requests it is the source branch                                                                                       |
 | FCI_TAG                  | The tag being built if started from a tag webhook, unset otherwise
 | FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form `owner_name/repository_name`. Unset for repositories added from custom source              |
@@ -68,23 +70,6 @@ Here is the list of Codemagic read-only environment variables that may be useful
   }
 ]
 ```
-
-## Build machine environment variables
-
-Here is the list of build machine read-only environment variables that may be useful in your build configuration. See the [build machine specs](../specs/machine-type/) for the most up to date versions of pre-installed software.
-
-| **Environment variable**       | **Value**                                                                            |
-| ------------------------------ | ------------------------------------------------------------------------------------ |
-| ANDROID_NDK_ROOT               | Absolute path to Android NDK                                                         |
-| ANDROID_SDK_ROOT               | Absolute path to Android SDK and tools                                               |
-| FLUTTER_ROOT                   | Absolute path to Flutter SDK                                                         |
-| GRADLE_HOME                    | Absolute path to Gradle home directory                                               |
-| HOME                           | Absolute path to build root folder                                                   |
-| JAVA_HOME                      | Absolute path to Java home directory                                                 |
-| RBENV_VERSION                  | Ruby version                                                                         |
-| SNAPCRAFT_BUILD_ENVIRONMENT    | Snap Craft build environment                                                         |
-| SHELL                          | Absolute path to currently running shell program                                     |
-| TMPDIR                         | Absolute path to dir to use for temporary files                                      |
 
 ## Using environment variables
 

--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -22,7 +22,7 @@ set -ex
 printenv
 ```
 
-Here you'll find the description of Codemagic read-only environment variables that may be useful in your build configuration.
+Here is the list of Codemagic read-only environment variables that may be useful in your build configuration.
 
 | **Environment variable** | **Value**                                                                                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -53,8 +53,6 @@ Here you'll find the description of Codemagic read-only environment variables th
 | FCI_KEY_ALIAS            | Alias of the key as configured in the UI                                                                                                                        |
 | FCI_KEYSTORE_PATH        | Path of the file in our VM                                                                                                                                      |
 | FCI_ARTIFACT_LINKS       | Information about generated build artifacts that is available in post-publishing step. Read more about it below.                                                |
-| FCI_DEVELOPER_DIR        | Absolute path to ?                                                                                                                                              |
-| FLUTTERCI_DEVELOPER_DIR  | Absolute path to ?                                                                                                                                              |
 
 `$FCI_ARTIFACT_LINKS` environment variable value is a JSON encoded list in the following form:
 
@@ -73,36 +71,20 @@ Here you'll find the description of Codemagic read-only environment variables th
 
 ## Build machine environment variables
 
-Here you'll find the description of build machine read-only environment variables that may be useful in your build configuration. See the [build machine specs](../specs/machine-type/) for the most up to date versions of pre-installed software.
+Here is the list of build machine read-only environment variables that may be useful in your build configuration. See the [build machine specs](../specs/machine-type/) for the most up to date versions of pre-installed software.
 
 | **Environment variable**       | **Value**                                                                            |
 | ------------------------------ | ------------------------------------------------------------------------------------ |
-| ADB_INSTALL_TIMEOUT            | ?                                                                                    |
-| ANDROID_HOME                   | Absolute path to Android SDK and tools                                               |
-| ANDROID_NDK_HOME               | Absolute path to Android NDK                                                         |
 | ANDROID_NDK_ROOT               | Absolute path to Android NDK                                                         |
-| ANDROID_PREFS_ROOT             | Absolute path to Android SDK and tools                                               |
 | ANDROID_SDK_ROOT               | Absolute path to Android SDK and tools                                               |
 | FLUTTER_ROOT                   | Absolute path to Flutter SDK                                                         |
-| GIT_MERGE_AUTOEDIT             | ?                                                                                    |
-| GOOGLE_APPLICATION_CREDENTIALS | ?                                                                                    |
 | GRADLE_HOME                    | Absolute path to Gradle home directory                                               |
 | HOME                           | Absolute path to build root folder                                                   |
 | JAVA_HOME                      | Absolute path to Java home directory                                                 |
-| LANG                           | ?                                                                                    |
-| LANGUAGE                       | ?                                                                                    |
-| LC_ALL                         | ?                                                                                    |
-| LC_CTYPE                       | ?                                                                                    |
-| NDK_HOME                       | Absolute path to Android NDK                                                         |
 | RBENV_VERSION                  | Ruby version                                                                         |
 | SNAPCRAFT_BUILD_ENVIRONMENT    | Snap Craft build environment                                                         |
 | SHELL                          | Absolute path to currently running shell program                                     |
-| SSH_AGENT_PID                  | ?                                                                                    |
-| SSH_AUTH_SOCK                  | ?                                                                                    |
-| SSH_CLIENT                     | ?                                                                                    |
-| SSH_CONNECTION                 | ?                                                                                    |
 | TMPDIR                         | Absolute path to dir to use for temporary files                                      |
-| USER                           | System user                                                                          |
 
 ## Using environment variables
 

--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -22,16 +22,14 @@ set -ex
 printenv
 ```
 
-Here you'll find some of the read-only environment variables explained.
+Here you'll find the description of Codemagic read-only environment variables that may be useful in your build configuration.
 
 | **Environment variable** | **Value**                                                                                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ANDROID_SDK_ROOT         | Absolute path to Android SDK and tools                                                                                                                          |
 | CI                       | true                                                                                                                                                            |
 | CONTINUOUS_INTEGRATION   | true                                                                                                                                                            |
 | BUILD_NUMBER             | Number of the build for this project in Codemagic for the given workflow                                                                                        |
 | PROJECT_BUILD_NUMBER     | Number of the build for this project in Codemagic                                                                                                               |
-| FLUTTER_ROOT             | Absolute path to Flutter SDK                                                                                                                                    |
 | FCI_BRANCH               | The current branch being built, for pull requests it is the source branch                                                                                       |
 | FCI_TAG                  | The tag being built if started from a tag webhook, unset otherwise
 | FCI_REPO_SLUG            | The slug of the repository that is currently being built in the form `owner_name/repository_name`. Unset for repositories added from custom source              |
@@ -55,6 +53,8 @@ Here you'll find some of the read-only environment variables explained.
 | FCI_KEY_ALIAS            | Alias of the key as configured in the UI                                                                                                                        |
 | FCI_KEYSTORE_PATH        | Path of the file in our VM                                                                                                                                      |
 | FCI_ARTIFACT_LINKS       | Information about generated build artifacts that is available in post-publishing step. Read more about it below.                                                |
+| FCI_DEVELOPER_DIR        | Absolute path to ?                                                                                                                                              |
+| FLUTTERCI_DEVELOPER_DIR  | Absolute path to ?                                                                                                                                              |
 
 `$FCI_ARTIFACT_LINKS` environment variable value is a JSON encoded list in the following form:
 
@@ -70,6 +70,39 @@ Here you'll find some of the read-only environment variables explained.
   }
 ]
 ```
+
+## Build machine environment variables
+
+Here you'll find the description of build machine read-only environment variables that may be useful in your build configuration. See the [build machine specs](../specs/machine-type/) for the most up to date versions of pre-installed software.
+
+| **Environment variable**       | **Value**                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------------ |
+| ADB_INSTALL_TIMEOUT            | ?                                                                                    |
+| ANDROID_HOME                   | Absolute path to Android SDK and tools                                               |
+| ANDROID_NDK_HOME               | Absolute path to Android NDK                                                         |
+| ANDROID_NDK_ROOT               | Absolute path to Android NDK                                                         |
+| ANDROID_PREFS_ROOT             | Absolute path to Android SDK and tools                                               |
+| ANDROID_SDK_ROOT               | Absolute path to Android SDK and tools                                               |
+| FLUTTER_ROOT                   | Absolute path to Flutter SDK                                                         |
+| GIT_MERGE_AUTOEDIT             | ?                                                                                    |
+| GOOGLE_APPLICATION_CREDENTIALS | ?                                                                                    |
+| GRADLE_HOME                    | Absolute path to Gradle home directory                                               |
+| HOME                           | Absolute path to build root folder                                                   |
+| JAVA_HOME                      | Absolute path to Java home directory                                                 |
+| LANG                           | ?                                                                                    |
+| LANGUAGE                       | ?                                                                                    |
+| LC_ALL                         | ?                                                                                    |
+| LC_CTYPE                       | ?                                                                                    |
+| NDK_HOME                       | Absolute path to Android NDK                                                         |
+| RBENV_VERSION                  | Ruby version                                                                         |
+| SNAPCRAFT_BUILD_ENVIRONMENT    | Snap Craft build environment                                                         |
+| SHELL                          | Absolute path to currently running shell program                                     |
+| SSH_AGENT_PID                  | ?                                                                                    |
+| SSH_AUTH_SOCK                  | ?                                                                                    |
+| SSH_CLIENT                     | ?                                                                                    |
+| SSH_CONNECTION                 | ?                                                                                    |
+| TMPDIR                         | Absolute path to dir to use for temporary files                                      |
+| USER                           | System user                                                                          |
 
 ## Using environment variables
 

--- a/content/building/environment-variables.md
+++ b/content/building/environment-variables.md
@@ -26,6 +26,7 @@ Here you'll find some of the read-only environment variables explained.
 
 | **Environment variable** | **Value**                                                                                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ANDROID_SDK_ROOT         | Absolute path to Android SDK and tools                                                                                                                          |
 | CI                       | true                                                                                                                                                            |
 | CONTINUOUS_INTEGRATION   | true                                                                                                                                                            |
 | BUILD_NUMBER             | Number of the build for this project in Codemagic for the given workflow                                                                                        |

--- a/content/getting-started/building-a-native-android-app.md
+++ b/content/getting-started/building-a-native-android-app.md
@@ -74,7 +74,7 @@ workflows:
           source: true
     scripts:
       - name: Set up local properties
-        script: echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/local.properties"
+        script: echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/local.properties"
       - name: Set up key.properties file for code signing
         script: |
           echo $FCI_KEYSTORE | base64 --decode > $FCI_KEYSTORE_PATH

--- a/content/getting-started/building-a-react-native-app.md
+++ b/content/getting-started/building-a-react-native-app.md
@@ -35,7 +35,7 @@ You can find an up-to-date codemagic.yaml React Native Android workflow in [Code
 Set up local properties
 
 ```yaml
-- echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/android/local.properties"
+- echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/android/local.properties"
 ```
 
 Building an Android application:

--- a/content/getting-started/building-an-ionic-app.md
+++ b/content/getting-started/building-an-ionic-app.md
@@ -70,7 +70,7 @@ workflows:
           npm install
       - name: Set Android SDK location
         script: |
-          echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/android/local.properties"
+          echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/android/local.properties"
       - name: Set up keystore
         script: |
           echo $FCI_KEYSTORE | base64 --decode > /tmp/keystore.keystore

--- a/content/getting-started/building_a_native_app_with_flutter_module.md
+++ b/content/getting-started/building_a_native_app_with_flutter_module.md
@@ -20,7 +20,7 @@ Using a Flutter module as a library means that it will be built from the source 
 
 ```yaml
 scripts:
-  - echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/my_host_app/local.properties"
+  - echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/my_host_app/local.properties"
   - cd my_flutter_module && flutter pub get
   - cd my_host_app && ./gradlew assembleDebug
 ```
@@ -61,7 +61,7 @@ Using a prebuilt module means that you don't need to build it every time the hos
 ```yaml
 scripts:
   - echo 'previous step'
-  - echo "sdk.dir=$HOME/programs/android-sdk-macosx" > "$FCI_BUILD_DIR/my_host_app/local.properties"
+  - echo "sdk.dir=$ANDROID_SDK_ROOT" > "$FCI_BUILD_DIR/my_host_app/local.properties"
   - name: Precompile the Flutter module
     script: |
       cd my_flutter_module

--- a/content/specs/machine-type.md
+++ b/content/specs/machine-type.md
@@ -14,7 +14,7 @@ For Flutter projects configured via the Flutter workflow editor, the build machi
 
 ## Mac Mini and Mac Pro
 
-Codemagic offers two types of macOS machines for running builds: Mac mini (macOS standard VM, default) and Mac Pro (macOS premium VM). Specifications for these machines are available [here](../specs/versions2/#hardware). 
+Codemagic offers two types of macOS machines for running builds: Mac mini (macOS standard VM, default) and Mac Pro (macOS premium VM). Specifications for these machines are available for [Xcode 11.x](../specs/versions/#hardware), [Xcode 12.0 - 12.4](../specs/versions2/#hardware), and [Xcode 12.5](../specs/versions3/#hardware). 
 
 {{<notebox>}}
 Mac Pro machines are only available for teams and users that have [billing enabled](../billing/billing). See the [pricing page](https://codemagic.io/pricing/) for the per minute rate.


### PR DESCRIPTION
Xcode update from [12.4](https://docs.codemagic.io/specs/versions2/) to [12.5](https://docs.codemagic.io/specs/versions3/) broke builds based on the examples because of the change of the Android SDK path. This PR prevents misleading users in the future.

https://github.com/codemagic-ci-cd/codemagic-sample-projects/pull/2 to update sample projects