### PR TITLE
rephrase "stop build if tests fail" description

### DIFF
--- a/content/testing/running-automated-tests.md
+++ b/content/testing/running-automated-tests.md
@@ -59,4 +59,4 @@ flutter emulators --launch emulator
 
 ### Stop build if tests fail
 
-Selecting the **Stop build if tests fail** option will stop the build immediately when any of the tests fail. Such builds will have the status "failed".
+Selecting the **Stop build if tests fail** option will stop the build after finishing all the enabled tests when any of the tests fail. Such builds will have the status "failed".

--- a/content/testing/static-code-analysis.md
+++ b/content/testing/static-code-analysis.md
@@ -6,8 +6,8 @@ weight: 2
 
 Test your code with `flutter analyze` to find possible mistakes. You can read more about this feature in [Dart documentation](https://dart.dev/guides/language/analysis-options). By default, static code analysis is disabled and has to be enabled in **App settings > Test** by checking the **Enable Flutter analyzer** option.
 
-To run `flutter analyze`, Codemagic specifies the `analyze` command in the **Flutter analyze arguments** field. You can pass additional arguments to customize static code analysis. For example, adding `--write=analyzer-output.txt` prints the results of static code analysis into a text file. 
+To run `flutter analyze`, Codemagic specifies the `analyze` command in the **Flutter analyze arguments** field. You can pass additional arguments to customize static code analysis. For example, adding `--write=analyzer-output.txt` prints the results of static code analysis into a text file.
 
-If you check **Stop build if tests fail**, the build will fail if any issues are detected during static code analysis.
+If you check **Stop build if tests fail**, the build will stop after finishing all the enabled tests when any of the tests fail. Such builds will have the status "failed".
 
 When enabled, `flutter analyze` will be run with each build. You can see the results and the logs of the analysis under the **Running tests** step in build overview.


### PR DESCRIPTION
The previous description implies that a build will stop immediately if a test fails, but the checkbox is related to the whole test step, and all the enabled tests will run.

Inspired by https://codemagicio.slack.com/archives/CEKE2KZ37/p1621004312408700