### PR TITLE
add --warn-only flag

### DIFF
--- a/content/getting-started/building-a-react-native-app.md
+++ b/content/getting-started/building-a-react-native-app.md
@@ -196,7 +196,7 @@ workflows:
           agvtool new-version -all $(($(app-store-connect get-latest-testflight-build-number "$APP_STORE_APP_ID") + 1))
       - name: Set up code signing settings on Xcode project
         script: |
-          xcode-project use-profiles
+          xcode-project use-profiles --warn-only
       - name: Build ipa for distribution
         script: |
           xcode-project build-ipa --workspace "$FCI_BUILD_DIR/ios/$XCODE_WORKSPACE" --scheme "$XCODE_SCHEME" 


### PR DESCRIPTION
There have been several occasions when React Native projects contain a dependency that also contains an .xcodeproj and Codemagic tries to find a provisioning profile to match the project which in turn causes the build to fail. Adding the --warn-only flag will just show a warning instead of making the build fail unnecessarily. 