### PR TITLE
Add Algolia search

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -98,10 +98,8 @@ const updateUrl = (query) =>
 const updateResults = async (query) => {
     let result, algoliaResult
     try {
-        result = getResults(query)
-        console.log("fuse: ", result)
+        // result = getResults(query)
         algoliaResult = await getAlgoliaResults(query)
-        console.log("algolia: ", algoliaResult)
     } catch (error) {
         result = error
     }

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -290,12 +290,8 @@ const getAlgoliaResults = (query) =>
     query
         ? algolia
             .search(`'${query}`, {
-                hitsPerPage: 16,
                 highlightPreTag: '<mark data-markjs="true">',
                 highlightPostTag: '</mark>',
-                attributesToSnippet: [
-                    'content:100',
-                ]
             }).then((result) => {
                 return result.hits;
             })

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,37 +1,8 @@
-let fuse
 
 const algolia = algoliasearch("27CIRMYZIB", "7e88305c04e90188508daa6c89e5f4df").initIndex("codemagic_docs");
 
-const fuseOptions = {
-    includeMatches: true,
-    findAllMatches: true,
-    includeScore: true,
-    threshold: 0,
-    ignoreLocation: true,
-    maxPatternLength: 32,
-    minMatchCharLength: 3,
-    useExtendedSearch: true,
-    keys: [
-        {
-            name: 'title',
-            weight: 15,
-        },
-        {
-            name: 'subtitle',
-            weight: 10,
-        },
-        {
-            name: 'content',
-            weight: 5,
-        },
-    ],
-}
-
 $(document).ready(() => {
-    $.getJSON('/index.json', (data) => {
-        fuse = new Fuse(data, fuseOptions)
-        initSearchEvents()
-    })
+    initSearchEvents()
 })
 
 const initSearchEvents = () => {
@@ -94,17 +65,14 @@ const updateUrl = (query) =>
             (query ? '?q=' + encodeURIComponent(query) : ''),
     )
 
-// TODO - Remove fuse or algolia search after deciding which to keep
 const updateResults = async (query) => {
-    let result, algoliaResult
+    let result
     try {
-        // result = getResults(query)
-        algoliaResult = await getAlgoliaResults(query)
+        result = await getResults(query)
     } catch (error) {
         result = error
     }
-    // $('#search-results').html(getResultHtml(result, query))
-    $('#search-results').html(getAlgoliaResultHtml(algoliaResult, query))
+    $('#search-results').html(getResultHtml(result, query))
 }
 
 const updateInputs = (query) => {
@@ -113,148 +81,7 @@ const updateInputs = (query) => {
     query === null ? $inputs.trigger('blur') : query && $('.search').addClass('search--active')
 }
 
-const getResultHtml = (resultList, query) => {
-    if (!resultList) return null
-
-    if (resultList instanceof Error) {
-        return $('<div>', {
-            class: 'no-results-message',
-            text: 'Invalid search query: ' + resultList.message,
-        })
-    }
-
-    if (!resultList.length) {
-        return $('<div>', {
-            class: 'no-results-message',
-            text: 'No results matching "' + query + '"',
-        })
-    }
-
-    const orderByStartPosition = (a, b) => a.start - b.start
-
-    const collectSnippetPositions = (contentLength, all, p) => {
-        const charsBefore = 30
-        const charsAfter = 30
-        const maxSnippetLength = 200
-
-        const start = Math.max(p.start - charsBefore, 0)
-        const end = Math.min(p.start + p.length + charsAfter, contentLength)
-
-        const prev = all[all.length - 1]
-        const isOverlappingWithPrevious = prev && prev.start + prev.length > start
-        if (isOverlappingWithPrevious) {
-            const newLength = end - prev.start
-            if (newLength > maxSnippetLength) {
-                return all
-            }
-            prev.length = newLength
-            prev.keywords.push({ start: p.start - prev.start, length: p.length })
-        } else {
-            all.push({
-                start: start,
-                length: end - start,
-                keywords: [{ start: p.start - start, length: p.length }],
-            })
-        }
-
-        return all
-    }
-
-    const getSnippet = (content, s) => {
-        let c = content.substr(s.start, s.length + 1)
-        const m = c.match(new RegExp('|', 'g'))
-
-        const isStartOfContent = s.start === 0
-        const firstKw = s.keywords[0]
-        const start = isStartOfContent ? 0 : Math.min(firstKw.start, m ? c.indexOf(m[0]) + m[0].length : 0)
-        const lastKw = s.keywords[s.keywords.length - 1]
-
-        const isEndOfContent = s.start + s.length === content.length
-        const end = isEndOfContent
-            ? c.length + 1
-            : Math.max(lastKw.start + lastKw.length, m ? c.lastIndexOf(m[m.length - 1]) : c.length + 1)
-
-        c = c.substring(start, end)
-
-        return Object.assign({}, s, {
-            content: c,
-            isStart: isStartOfContent,
-            isEnd: isEndOfContent,
-            keywords: s.keywords.map((k) => {
-                return { start: k.start - start, length: k.length }
-            }),
-        })
-    }
-
-    const getContentSnippets = (contentPositions, content) => {
-        content = (content || '').trim()
-
-        return contentPositions
-            ? contentPositions
-                  .sort(orderByStartPosition)
-                  .reduce(collectSnippetPositions.bind(null, content.length), [])
-                  .map(getSnippet.bind(null, content))
-                  .slice(0, 3)
-            : [
-                  {
-                      isFirst: true,
-                      isLast: false,
-                      content: content.substring(0, 100),
-                      keywords: contentPositions,
-                  },
-              ]
-    }
-
-    return $('<ul>', {
-        html: resultList.map((result) => {
-            const snippets = getContentSnippets(result.positions.content, result.item.content)
-
-            return $('<li>', {
-                html: [
-                    $('<a>', { text: result.item.title, href: result.item.uri }).markRanges(result.positions.title),
-                    $('<p>', { text: result.item.subtitle }),
-                    snippets
-                        ? $('<p>', {
-                              html: snippets.map((s) => {
-                                  return $('<span>', {
-                                      class: [s.isStart ? 'start' : '', s.isEnd ? 'end' : ''].join(' '),
-                                      text: s.content,
-                                  }).markRanges(s.keywords)
-                              }),
-                          })
-                        : null,
-                ],
-            })
-        }),
-    })
-}
-
-const getResults = (query) =>
-    query
-        ? fuse
-              // ' is a token for extended search needed to find items that include the value
-              // it prevents fuzzy search
-              .search(`'${query}`, {
-                  limit: 16,
-              })
-              .map((result) => {
-                  let positions = { title: [], subtitle: [], content: [] }
-                  result.matches.map((match) => {
-                      match.indices.map((index) => {
-                          positions[match.key].push({
-                              length: index[1] - index[0] + 1,
-                              start: index[0],
-                          })
-                      })
-                  })
-                  return {
-                      ...result,
-                      positions,
-                  }
-              })
-        : null
-
-const getAlgoliaResultHtml = (algoliaResultList, query) => {
+const getResultHtml = (algoliaResultList, query) => {
     if (!algoliaResultList) return null
 
     if (algoliaResultList instanceof Error) {
@@ -284,7 +111,7 @@ const getAlgoliaResultHtml = (algoliaResultList, query) => {
     })
 }
 
-const getAlgoliaResults = (query) =>
+const getResults = (query) =>
     query
         ? algolia
             .search(`'${query}`, {

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -4,6 +4,7 @@
     integrity="sha384-iqnguDoMujGknA4B5Jk7pbSn7sb7M8Tc0zVsTNQXm629Xx00jGEpD9TsZXbfNjKO"
     crossorigin="anonymous"
 ></script>
+<script defer src="https://cdn.jsdelivr.net/npm/algoliasearch@4.5.1/dist/algoliasearch-lite.umd.js"></script>
 
 {{ $searchScript := resources.Get "js/search.js" | minify | fingerprint }}
 <script defer src="{{ $searchScript.RelPermalink }}" integrity="{{ $searchScript.Data.Integrity }}"></script>

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,4 +1,3 @@
-<script defer src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.6/dist/fuse.min.js"></script>
 <script
     src="https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/jquery.mark.min.js"
     integrity="sha384-iqnguDoMujGknA4B5Jk7pbSn7sb7M8Tc0zVsTNQXm629Xx00jGEpD9TsZXbfNjKO"


### PR DESCRIPTION
I added [Algolia search](https://www.algolia.com/products/search/) using their [javascript client](https://github.com/algolia/algoliasearch-client-javascript).

TODO
- [x] decide if console.log(...) is OK so we can check Algolia vs. Fuse search results if need be (remove console.log)
- [x] decide best way to leave existing code so we can revert back to it in a week or two if we're unhappy with Algolia (remove fuse code)
- [ ] when deploying codemagic docs we need to set up a trigger to update the `codemagic_docs` index in Algolia ([API call](https://www.algolia.com/doc/api-reference/api-methods/replace-all-objects/?client=javascript)) with the up to date `index.json` file


Algolia "Flutter Android Signing" search
![Screen Shot 2021-05-19 at 15 54 06](https://user-images.githubusercontent.com/431915/118817601-0e682200-b8bc-11eb-9e26-cad5235dbe93.png)

Existing "Flutter Android Signing" search
![Screen Shot 2021-05-19 at 15 47 19](https://user-images.githubusercontent.com/431915/118817659-2049c500-b8bc-11eb-9920-2bc690bbda7c.png)
