### PR TITLE
Provide users with scripts that are compatible with both MacOS and current Linux VMs

### DIFF
--- a/content/knowledge-base/add-a-git-tag-with-app-version.md
+++ b/content/knowledge-base/add-a-git-tag-with-app-version.md
@@ -22,12 +22,12 @@ Pushing Git tags from Codemagic to repository requires **write access** to the r
 2. Add the following **pre-publish script**.  Note that you need to replace the placeholders with your actual environment variable name and Git service details.
 
   ```bash
-  #!/usr/bin/env sh
+  #!/usr/bin/env bash
 
   set -e # exit on first failed commandset
   set -x # print all executed commands to the log
 
-  if [ "$FCI_BUILD_STEP_STATUS" == "success" ]
+  if [ "$FCI_BUILD_STEP_STATUS" = "success" ]
   then
     new_version=v1.0.$BUILD_NUMBER
     git tag $new_version

--- a/content/publishing/beta-deployment-with-fastlane.md
+++ b/content/publishing/beta-deployment-with-fastlane.md
@@ -10,12 +10,12 @@ If your Flutter app has an existing *fastlane* setup for beta deployment, you ca
 2. Click on the + sign between **Build** and **Publish** and paste your script to the pre-publish script field.
 
 ```bash
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e # exit on first failed command
 set -x # print all executed commands to the log
 
-if [ "$FCI_BUILD_STEP_STATUS" == "success" ]
+if [ "$FCI_BUILD_STEP_STATUS" = "success" ]
 then
         gem install bundler
         cd android


### PR DESCRIPTION
I was using code from https://docs.codemagic.io/knowledge-base/add-a-git-tag-with-app-version/. That started failing when I started using Linux VMs.

It appears that https://docs.codemagic.io/publishing/beta-deployment-with-fastlane/ would suffer from the same issue. There might be a way to support zsh instead or sh directly, but I wasn't sure what you would prefer so I defaulted to bash to just get it done.