### PR TITLE
CD into iOS folder before running agvtool

### DIFF
--- a/content/building/build-versioning.md
+++ b/content/building/build-versioning.md
@@ -103,6 +103,7 @@ Add the following script under your `scripts` field for `codemagic.yaml`, or as 
 ```bash
 export APP_STORE_CONNECT_PRIVATE_KEY=$(echo $APP_STORE_CONNECT_PRIVATE_KEY | base64 --decode) # if you encrypted the file itself, not its content
 LATEST_BUILD_NUMBER=$(app-store-connect get-latest-app-store-build-number '1234567890') # The argument is your application's Apple ID
+cd $FCI_BUILD_DIR/ios
 agvtool new-version -all $(($LATEST_BUILD_NUMBER + 1))
 ```
 
@@ -111,6 +112,7 @@ To use the latest build number from Testflight use a similar script:
 ```bash
 export APP_STORE_CONNECT_PRIVATE_KEY=$(echo $APP_STORE_CONNECT_PRIVATE_KEY | base64 --decode) # if you encrypted the file itself, not its content
 LATEST_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number '1234567890') # The argument is your application's Apple ID
+cd $FCI_BUILD_DIR/ios
 agvtool new-version -all $(($LATEST_BUILD_NUMBER + 1))
 ```
 

--- a/content/building/build-versioning.md
+++ b/content/building/build-versioning.md
@@ -103,7 +103,7 @@ Add the following script under your `scripts` field for `codemagic.yaml`, or as 
 ```bash
 export APP_STORE_CONNECT_PRIVATE_KEY=$(echo $APP_STORE_CONNECT_PRIVATE_KEY | base64 --decode) # if you encrypted the file itself, not its content
 LATEST_BUILD_NUMBER=$(app-store-connect get-latest-app-store-build-number '1234567890') # The argument is your application's Apple ID
-cd $FCI_BUILD_DIR/ios
+cd ./ios # Set working directory to iOS project directory as agvtool should run in directory with .xcodeproj file
 agvtool new-version -all $(($LATEST_BUILD_NUMBER + 1))
 ```
 
@@ -112,7 +112,7 @@ To use the latest build number from Testflight use a similar script:
 ```bash
 export APP_STORE_CONNECT_PRIVATE_KEY=$(echo $APP_STORE_CONNECT_PRIVATE_KEY | base64 --decode) # if you encrypted the file itself, not its content
 LATEST_BUILD_NUMBER=$(app-store-connect get-latest-testflight-build-number '1234567890') # The argument is your application's Apple ID
-cd $FCI_BUILD_DIR/ios
+cd ./ios # Set working directory to iOS project directory as agvtool should run in directory with .xcodeproj file
 agvtool new-version -all $(($LATEST_BUILD_NUMBER + 1))
 ```
 


### PR DESCRIPTION
I think for most use cases where people copy and paste this script they will forget to `cd` into the ios directory.