### PR TITLE
Update Flutter integration tests 

### DIFF
--- a/content/testing-yaml/testing.md
+++ b/content/testing-yaml/testing.md
@@ -47,7 +47,7 @@ Chrome
 ```yaml
 scripts:
   - echo 'previous step'
-  - name: 'Flutter integration_test for web'
+  - name: 'Flutter integration test for web'
     script: |
       chromedriver --port=4444 &
       flutter config --enable-web
@@ -59,7 +59,7 @@ Safari
 ```yaml
 scripts:
   - echo 'previous step'
-  - name: 'Flutter integration tests for web'
+  - name: 'Flutter integration test for web'
     script: |
       sudo safaridriver --enable
       safaridriver --port 4444 &

--- a/content/testing-yaml/testing.md
+++ b/content/testing-yaml/testing.md
@@ -37,7 +37,7 @@ The `integration_test` dependency allows you to run integration tests on a real 
 
 ```bash
 flutter emulators --launch apple_ios_simulator             # for android use: flutter emulators --launch emulator
-flutter drive --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d <device_id>
+flutter drive --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d iPhone  # for android use: -d emulator-5554 
 ```
 
 ### Running web application tests on a web browser driver

--- a/content/testing-yaml/testing.md
+++ b/content/testing-yaml/testing.md
@@ -31,13 +31,13 @@ scripts:
 
 ## Flutter integration tests
 
-The `flutter_driver` dependency allows you to run integration tests on a real device or emulator. Android application tests can be run on an Android emulator, iOS application tests can be run on an iOS simulator, and web application tests can be run on a web browser driver.
+The `integration_test` dependency allows you to run integration tests on a real device or emulator. Android application tests can be run on an Android emulator, iOS application tests can be run on an iOS simulator, and web application tests can be run on a web browser driver.
 
 ### Running iOS/Android application tests on a mobile simulator/emulator
 
 ```bash
 flutter emulators --launch apple_ios_simulator             # for android use: flutter emulators --launch emulator
-flutter drive --target=test_driver/my_drive_target.dart
+flutter drive --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d <device_id>
 ```
 
 ### Running web application tests on a web browser driver
@@ -47,11 +47,11 @@ Chrome
 ```yaml
 scripts:
   - echo 'previous step'
-  - name: 'Flutter drive web test'
+  - name: 'Flutter integration_test for web'
     script: |
       chromedriver --port=4444 &
       flutter config --enable-web
-      flutter drive --target=test_driver/button_pressing.dart -d chrome --browser-name chrome --release
+      flutter driver --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d web-server --release --browser-name chrome
 ```
 
 Safari
@@ -59,12 +59,12 @@ Safari
 ```yaml
 scripts:
   - echo 'previous step'
-  - name: 'Flutter drive web test'
+  - name: 'Flutter integration tests for web'
     script: |
       sudo safaridriver --enable
       safaridriver --port 4444 &
       flutter config --enable-web
-      flutter drive --target=test_driver/button_pressing.dart --browser-name safari --release
+      flutter driver --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d web-server --release --browser-name safari
 ```
 
 ## React Native Unit Tests using Jest

--- a/content/testing-yaml/testing.md
+++ b/content/testing-yaml/testing.md
@@ -51,7 +51,7 @@ scripts:
     script: |
       chromedriver --port=4444 &
       flutter config --enable-web
-      flutter driver --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d web-server --release --browser-name chrome
+      flutter drive --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d web-server --release --browser-name chrome
 ```
 
 Safari
@@ -64,7 +64,7 @@ scripts:
       sudo safaridriver --enable
       safaridriver --port 4444 &
       flutter config --enable-web
-      flutter driver --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d web-server --release --browser-name safari
+      flutter drive --driver=test_driver/integration_driver.dart --target=integration_test/app_test.dart -d web-server --release --browser-name safari
 ```
 
 ## React Native Unit Tests using Jest


### PR DESCRIPTION
Tested the commands and updated the commands for `integration_test`.

Notes on some changes;
`-d <device_id>` is required since now all Flutter channels have web is enabled by default, without this, `integration_test` would target web unintentionally. 
`-d web-server` is required to target `non-web` platform for release mode, if you omit  it, release mode test will fail. 

