### PR TITLE
App store connect publisher documentation updates

### DIFF
--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -118,7 +118,7 @@ publishing:
     api_key: Encrypted(...)           # Contents of the API key, can also reference environment variable such as $APP_STORE_CONNECT_PRIVATE_KEY
     key_id: 3MD9688D9K                # Alphanumeric value that identifies the API key, can also reference environment variable such as $APP_STORE_CONNECT_KEY_IDENTIFIER
     issuer_id: 21d78e2f-b8ad-...      # Alphanumeric value that identifies who created the API key, can also reference environment variable such as $APP_STORE_CONNECT_ISSUER_ID
-    submit_to_testflight: True        # Optional boolean, defaults to false. Whether or not to submit the uploaded build to TestFlight
+    submit_to_testflight: True        # Optional boolean, defaults to false. Whether or not to submit the uploaded build to TestFlight to automatically enroll your build to beta testers.  
 ```
 
 ## GitHub releases

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -106,7 +106,7 @@ You can override the publishing track specified in the configuration file using 
 
 ### App Store Connect
 
-Codemagic enables you to automatically publish your iOS or macOS app to [App Store Connect](https://appstoreconnect.apple.com/) for beta testing with [TestFlight](https://developer.apple.com/testflight/) or distributing the app to users via App Store. Codemagic uses the App Store Connect API key for authenticating communication with Apple's services. You can read more about generating an API key from Apple's [documentation page](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api). 
+Codemagic enables you to automatically publish your iOS or macOS app to [App Store Connect](https://appstoreconnect.apple.com/) for beta testing with [TestFlight](https://developer.apple.com/testflight/) or distributing the app to users via App Store. Codemagic uses **App Store Connect API key** for authenticating communication with Apple's services. You can read more about generating an API key from Apple's [documentation page](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api). 
 
 Please note that
 1. for App Store Connect publishing the provided key needs to have [App Manager permission](https://help.apple.com/app-store-connect/#/deve5f9a89d7),

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -83,7 +83,7 @@ publishing:
     track: alpha                      # Name of the track: internal, alpha, beta, production, internal app sharing, or your custom track name
     in_app_update_priority: 3         # Priority of the release (only set if in-app updates are supported): integer in range [0, 5]
     rollout_fraction: 0.25            # Rollout fraction (set only if releasing to a fraction of users): value between (0, 1)
-    changes_not_sent_for_review: True # To be used ONLY if your app cannot be sent for review automatically *
+    changes_not_sent_for_review: true # To be used ONLY if your app cannot be sent for review automatically *
 ```
 
 {{<notebox>}}
@@ -91,7 +91,7 @@ publishing:
 
 `Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.`
 
-If your changes are sent to review automatically, but the field is still set to `True`, you will get the next error:
+If your changes are sent to review automatically, but the field is still set to `true`, you will get the next error:
 
 `Changes are sent for review automatically. The query parameter changesNotSentForReview must not be set.`
 {{</notebox>}}
@@ -118,7 +118,7 @@ publishing:
     api_key: Encrypted(...)           # Contents of the API key, can also reference environment variable such as $APP_STORE_CONNECT_PRIVATE_KEY
     key_id: 3MD9688D9K                # Alphanumeric value that identifies the API key, can also reference environment variable such as $APP_STORE_CONNECT_KEY_IDENTIFIER
     issuer_id: 21d78e2f-b8ad-...      # Alphanumeric value that identifies who created the API key, can also reference environment variable such as $APP_STORE_CONNECT_ISSUER_ID
-    submit_to_testflight: True        # Optional boolean, defaults to false. Whether or not to submit the uploaded build to TestFlight to automatically enroll your build to beta testers.  
+    submit_to_testflight: true        # Optional boolean, defaults to false. Whether or not to submit the uploaded build to TestFlight to automatically enroll your build to beta testers.  
 ```
 
 ## GitHub releases

--- a/content/publishing-yaml/distribution.md
+++ b/content/publishing-yaml/distribution.md
@@ -106,13 +106,19 @@ You can override the publishing track specified in the configuration file using 
 
 ### App Store Connect
 
-Codemagic enables you to automatically publish your iOS or macOS app to App Store Connect for beta testing with TestFlight or distributing the app to users via App Store.
+Codemagic enables you to automatically publish your iOS or macOS app to [App Store Connect](https://appstoreconnect.apple.com/) for beta testing with [TestFlight](https://developer.apple.com/testflight/) or distributing the app to users via App Store. Codemagic uses the App Store Connect API key for authenticating communication with Apple's services. You can read more about generating an API key from Apple's [documentation page](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api). 
+
+Please note that
+1. for App Store Connect publishing the provided key needs to have [App Manager permission](https://help.apple.com/app-store-connect/#/deve5f9a89d7),
+2. and in order to submit your iOS application to App Store Connect, it must be code signed with a distribution [certificate](https://developer.apple.com/support/certificates/).  
 
 ```yaml
 publishing:
   app_store_connect:                  # For iOS or macOS app
-    apple_id: name@example.com        # Email address used for login
-    password: Encrypted(...)          # App-specific password
+    api_key: Encrypted(...)           # Contents of the API key, can also reference environment variable such as $APP_STORE_CONNECT_PRIVATE_KEY
+    key_id: 3MD9688D9K                # Alphanumeric value that identifies the API key, can also reference environment variable such as $APP_STORE_CONNECT_KEY_IDENTIFIER
+    issuer_id: 21d78e2f-b8ad-...      # Alphanumeric value that identifies who created the API key, can also reference environment variable such as $APP_STORE_CONNECT_ISSUER_ID
+    submit_to_testflight: True        # Optional boolean, defaults to false. Whether or not to submit the uploaded build to TestFlight
 ```
 
 ## GitHub releases

--- a/content/publishing/publishing-to-app-store.md
+++ b/content/publishing/publishing-to-app-store.md
@@ -4,7 +4,7 @@ title: App Store Connect
 weight: 1
 ---
 
-Codemagic enables you to automatically publish your app to App Store Connect for beta testing with TestFlight or distributing the app to users via App Store. To do so, you must first set up [iOS code signing](../code-signing/ios-code-signing/) and then configure publishing to App Store Connect.
+Codemagic enables you to automatically publish your app to App Store Connect for beta testing with TestFlight or distributing the app to users via App Store. To do so, you must first set up [iOS code signing](../code-signing/ios-code-signing/) using distribution code signing [certificate](https://developer.apple.com/support/certificates/) and then configure publishing to App Store Connect.
 
 {{<notebox>}}
 This guide only applies to workflows configured with the **Flutter workflow editor**. If your workflow is configured with **codemagic.yaml** please go to [Publishing to App Store Connect using codemagic.yaml](../publishing-yaml/distribution/#app-store-connect).
@@ -12,9 +12,9 @@ This guide only applies to workflows configured with the **Flutter workflow edit
 
 ## Requirements
 
-Codemagic needs your **Apple ID** and [**app-specific password**](https://support.apple.com/en-us/HT204397) to perform publishing to App Store Connect on your behalf. Publishing to App Store Connect requires that the app be signed with App Store **distribution certificate**.
+Codemagic needs your **[App Store Connect API key](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api)** to perform publishing to App Store Connect on your behalf. Publishing to App Store Connect requires that the app is code signed with a [distribution certificate](https://developer.apple.com/support/certificates/).
 
-In addition, the application must be **App Store ready** for build distribution, meaning that it must have all the correct icons and icon sizes, otherwise App Store Connect will tag the binary as invalid, and you will not be able to distribute it at all.
+In addition, the application must be **App Store ready** for build distribution, meaning that it must have all the correct icons and icon sizes. Otherwise App Store Connect will tag the binary as invalid, and you will not be able to distribute it at all.
 
 It is also worth pointing out the necessity for each uploaded binary to have a **different version**, otherwise it will be refused by App Store Connect. See the [Build versioning](../building/build-versioning/) article for instructions on incrementing app version with Codemagic.
 
@@ -22,10 +22,44 @@ It is also worth pointing out the necessity for each uploaded binary to have a *
 
 ## Setting up publishing to App Store Connect on Codemagic
 
-1. Navigate to the Publish section in app settings.
+In this section we give step-by-step instructions on how to configure publishing App Store Connect using Flutter workflow editor.
+
+### Step 1. Creating an App Store API key for Codemagic
+
+It is recommended to create a dedicated App Store Connect API key for Codemagic in [App Store Connect](https://appstoreconnect.apple.com/access/api). To do so:
+
+1. Log in to App Store Connect and navigate to **Users and Access > Keys**.
+2. Click on the + sign to generate a new API key.
+3. Enter the name for the key and select an access level. For App Store Connect publishing the key needs to have `App Manager` permissions. Read more about Apple Developer Program role permissions [here](https://help.apple.com/app-store-connect/#/deve5f9a89d7).
+4. Click **Generate**.
+5. As soon as the key is generated, you can see it added in the list of active keys. Click **Download API Key** to save the private key for later. Note that the key can only be downloaded once.
+
+{{<notebox >}} 
+Take note of the **Issuer ID** above the table of active keys as well as the **Key ID** of the generated key as these will be required when setting up the Apple Developer Portal integration in Codemagic UI.
+{{</notebox>}}
+
+### Step 2. Connecting the Apple Developer Portal integration for your team/account
+
+The Apple Developer Portal integration can be enabled in **User settings > Integrations** for personal projects and in **Team settings > Team integrations** for projects shared in the team (if you're the team owner). This allows you to conveniently use the same access credentials for publishing across different apps and workflows.
+
+1. In the list of available integrations, click the **Connect** button for **Developer Portal**.
+2. In the **App Store Connect API key name**, provide a name for the key you are going to set up the integration with. This is for identifying the key in Codemagic.
+3. Enter the **Issuer ID** related to your Apple Developer account. You can find it above the table of active keys on the Keys tab of the [Users and Access](https://appstoreconnect.apple.com/access/api) page.
+4. Enter the **Key ID** of the key to be used for code signing.
+5. In the **API key** field, upload the private API key downloaded from App Store Connect.
+6. Click **Save** to finish the setup.
+
+If you work with multiple Apple Developer teams, you can add additional keys by clicking **Add another key** right after adding the first key and repeating the steps described above. You can delete existing keys or add new ones when you click **Manage keys** next to the Developer Portal integration in user or team settings.
+
+### 3. Enabling App Store Connect publishing for workflow
+
+Once the Apple Developer Portal has been enabled for the account or team the app belongs to, you can easily enable App Store Connect publishing per workflow.
+
+1. Navigate to the Publish section in app settings **App settings > Publish**.
 2. Click **App Store Connect**.
-3. Enter your **Apple ID** (the email address used for login) and your [**app-specific password**](https://support.apple.com/en-us/HT204397).
-4. Select **Enable App Store Connect publishing** at the top of the section to enable publishing.
+3. If you have several keys available, select the right key in the **App Store Connect API key** field.
+4. Mark the **Submit to TestFlight** checkbox to automatically enroll your build to beta testers.  
+5. Select **Enable App Store Connect publishing** at the top of the section to enable publishing.
 
 Once you have successfully set up publishing to App Store Connect, Codemagic will automatically distribute the app to App Store Connect every time you build the workflow. Note that you must manually submit the app to App Store in App Store Connect.
 

--- a/content/publishing/publishing-to-app-store.md
+++ b/content/publishing/publishing-to-app-store.md
@@ -25,6 +25,10 @@ It is also worth pointing out the necessity for each uploaded binary to have a *
 In this section we give step-by-step instructions on how to configure publishing App Store Connect using Flutter workflow editor.
 
 ### Step 1. Creating an App Store API key for Codemagic
+    
+{{<notebox>}}
+You may also reuse any of the keys you've already set up for automatic [iOS](../code-signing/ios-code-signing/#automatic-code-signing) or [macOS](../code-signing/macos-code-signing/#automatic-code-signing) code signing.
+{{</notebox>}}
 
 It is recommended to create a dedicated App Store Connect API key for Codemagic in [App Store Connect](https://appstoreconnect.apple.com/access/api). To do so:
 


### PR DESCRIPTION
Update App Store Connect publisher documentation to reflect 
- the updated authentication method using App Store Connect API keys, and
- highlight the possibility to automatically submit the uploaded binary to TestFlight.