### PR TITLE
Reorganize publishing section

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -72,7 +72,7 @@ menu:
       weight: 3
       parent: setup-flutter
     - identifier: publishing
-      name: Publishing
+      name: Distribution and notifications
       weight: 4
       parent: setup-flutter
     - identifier: teams

--- a/content/code-signing/android-code-signing.md
+++ b/content/code-signing/android-code-signing.md
@@ -91,7 +91,7 @@ android {
 
 You are required to upload your keystore file and provide details about your key in order to receive signed builds on Codemagic.
 
-1. Navigate to the **Publish** section in app settings.
+1. Navigate to the **Distribution** section in app settings.
 2. Click **Android code signing**.
 3. Upload your release keystore file.
 4. Enter the **keystore password**, **key alias** and **key password**.

--- a/content/code-signing/ios-code-signing.md
+++ b/content/code-signing/ios-code-signing.md
@@ -84,7 +84,7 @@ If you work with multiple Apple Developer teams, you can add additional keys by 
 
 Once the Apple Developer Portal has been enabled for the account or team the app belongs to, you can easily enable automatic code signing per workflow.
 
-1. Go to **App settings > Publish > iOS code signing**.
+1. Go to **App settings > Distribution > iOS code signing**.
 2. Select **Automatic** as the code signing method. If you haven't enabled the Apple Developer Portal integration yet, you will be asked to enable it before you can continue configuration.
 3. If you have several keys available, select the right key in the **App Store Connect API key** field.
 4. Select the **provisioning profile type** used for provisioning the build. Codemagic will automatically select or generate a matching certificate for code signing. The provisioning profiles (except for Distribution) will include all the devices you have registered on your Apple Developer account at the time of creating the profile.
@@ -103,7 +103,7 @@ This is required when distributing your app via Apple Developer Enterprise Progr
 
 ### Setting up manual code signing
 
-1. Go to **App settings > Publish > iOS code signing**.
+1. Go to **App settings > Distribution > iOS code signing**.
 2. Select **Manual** as the code signing method.
 3. Upload your signing certificate (in `.p12` format). If your certificate is password-protected, enter the **Certificate password**. 
 4. Upload your provisioning profile (`.mobileprovision`). Note that if your app contains app extensions, you are required to upload an additional provisioning profile for each extension.

--- a/content/code-signing/macos-code-signing.md
+++ b/content/code-signing/macos-code-signing.md
@@ -82,7 +82,7 @@ If you work with multiple Apple Developer teams, you can add additional keys by 
 
 Once the Apple Developer Portal has been enabled for the account or team the app belongs to, you can easily enable automatic code signing per workflow.
 
-1. Go to **App settings > Publish > macOS code signing**.
+1. Go to **App settings > Distribution > macOS code signing**.
 2. Select **Automatic** as the code signing method. If you haven't enabled the Apple Developer Portal integration yet, you will be asked to enable it before you can continue configuration.
 3. If you have several keys available, select the right key in the **App Store Connect API key** field.
 4. Mark the checkbox **Project type setting > is Mac Catalyst** if you need a Mac Catalyst profile.
@@ -97,7 +97,7 @@ With the manual code signing method, you are required to upload the `Mac App Dis
 
 ### Setting up manual code signing
 
-1. Go to **App settings > Publish > iOS code signing**.
+1. Go to **App settings > Distribution > iOS code signing**.
 2. Select **Manual** as the code signing method.
 3. Upload your `Mac App Distribution` signing certificate (in `.p12` format). If your certificate is password-protected, enter the **Certificate password**.
 3. Upload your `Mac Installer Distribution` signing certificate (in `.p12` format). If your certificate is password-protected, enter the **Certificate password**.

--- a/content/publishing/beta-deployment-with-fastlane.md
+++ b/content/publishing/beta-deployment-with-fastlane.md
@@ -4,10 +4,10 @@ title: Run fastlane for beta deployment
 weight: 7
 ---
 
-If your Flutter app has an existing *fastlane* setup for beta deployment, you can easily run *fastlane* scripts as part of the Codemagic build process and publish to Crashlytics, for example. Note that our builder machines have *fastlane* pre-installed. You can use the pre-publish script example below to execute `fastlane beta` for successful Android builds.
+If your Flutter app has an existing *fastlane* setup for beta deployment, you can easily run *fastlane* scripts as part of the Codemagic build process and publish to Crashlytics, for example. Note that our build machines have *fastlane* pre-installed. You can use the pre-publish script example below to execute `fastlane beta` for successful Android builds.
 
 1. Before running the script, navigate to **App settings > Environment variables** and add the API keys / secrets required for authorizing with the third-party service as secure [environment variables](../building/environment-variables). 
-2. Click on the + sign between **Build** and **Publish** and paste your script to the pre-publish script field.
+2. Click on the + sign between **Build** and **Distribution** and paste your script to the pre-publish script field.
 
 ```bash
 #!/usr/bin/env bash

--- a/content/publishing/email-and-slack-notifications.md
+++ b/content/publishing/email-and-slack-notifications.md
@@ -6,7 +6,7 @@ weight: 8
 
 ## Email
 
-Email publishing settings can be found in **App settings > Publish > Email**.
+Email publishing settings can be found in **App settings > Notifications > Email**.
 
 Email publishing is the only publishing option that is enabled by default. Codemagic uses the email specified as the default one in the service you used to log in (Github, Bitbucket, Gitlab). You can add multiple email addresses.
 
@@ -24,7 +24,7 @@ Use only the part in angle brackets from the whole address line (e.g. `My awesom
 
 In order to set up publishing to Slack, you first need to connect the Slack workspace in **User settings > Integrations > Slack** for your personal apps and in **Teams > Your_team > Team integrations > Slack** for the team apps. 
 
-Once your Slack workspace is connected, you can enable Slack publishing and select a channel for publishing in **App settings > Publish > Slack** when using the workflow editor.
+Once your Slack workspace is connected, you can enable Slack publishing and select a channel for publishing in **App settings > Notifications > Slack** when using the workflow editor.
 
 In order to publish to **private channels**, you need to invite Codemagic app to the channels, otherwise the app does not have access to private channels. To invite Codemagic app to private channels, write `@codemagic` in the channel. If you are in the Codemagic web app, refresh the page and the new channel will become available in the dropdown menu.
 

--- a/content/publishing/publish-release-notes.md
+++ b/content/publishing/publish-release-notes.md
@@ -8,10 +8,10 @@ Create custom release notes file(s) to notify users of the changes as you publis
 
 Release notes can be published to:
 
-* **email**. The release notes will be included in the publishing email of a successful build if you have the publishing configured in **App settings > Publish > Email**.
-* **Slack**. The release notes will be included in the Slack notification of a successful build if you have the publishing configured in **App settings > Publish > Slack**.
-* **App Store Connect**. The release notes will be published to App Store Connect if you have the publishing configured in **App settings > Publish > App Store Connect**.
-* **Google Play**. The release notes will be published to Google Play Console if you have the publishing configured in **App settings > Publish > Google Play**.
+* **email**. The release notes will be included in the publishing email of a successful build if you have the publishing configured in **App settings > Notifications > Email**.
+* **Slack**. The release notes will be included in the Slack notification of a successful build if you have the publishing configured in **App settings > Notifications > Slack**.
+* **App Store Connect**. The release notes will be published to App Store Connect if you have the publishing configured in **App settings > Distribution > App Store Connect**.
+* **Google Play**. The release notes will be published to Google Play Console if you have the publishing configured in **App settings > Distribution > Google Play**.
 
 ## Setting up release notes
 

--- a/content/publishing/publishing-to-app-store.md
+++ b/content/publishing/publishing-to-app-store.md
@@ -59,7 +59,7 @@ If you work with multiple Apple Developer teams, you can add additional keys by 
 
 Once the Apple Developer Portal has been enabled for the account or team the app belongs to, you can easily enable App Store Connect publishing per workflow.
 
-1. Navigate to the Publish section in app settings **App settings > Publish**.
+1. Navigate to the Publish section in app settings **App settings > Distribution**.
 2. Click **App Store Connect**.
 3. If you have several keys available, select the right key in the **App Store Connect API key** field.
 4. Mark the **Submit to TestFlight** checkbox to automatically enroll your build to beta testers.  

--- a/content/publishing/publishing-to-codemagic-static-pages.md
+++ b/content/publishing/publishing-to-codemagic-static-pages.md
@@ -6,7 +6,7 @@ weight: 4
 
 You can publish your web app to a custom subdomain of `codemagic.app` for easy access.
 
-1. Go to **App settings > Publish > Codemagic Static Pages** to configure publishing to Codemagic Static Pages.  
+1. Go to **App settings > Distribution > Codemagic Static Pages** to configure publishing to Codemagic Static Pages.  
 2. Choose a subdomain name and enter it in the **Web page subdomain** field. By default, we suggest your app name as the subdomain name.
 3. Check **Publish artifacts even if tests fail** to publish the build even when one or more tests fail. Leaving this option unchecked will publish only successful builds that pass the tests, if any.
 4. Select **Enable Codemagic Static Pages publishing** at the top of the section to enable publishing.

--- a/content/publishing/snap-store.md
+++ b/content/publishing/snap-store.md
@@ -6,7 +6,7 @@ weight: 3
 
 The [snap packages](../flutter/flutter-projects/#building-snap-packages) you build in Codemagic can be published straight to the [Snapcraft Snap Store](https://snapcraft.io/) as part of the build workflow.
 
-1. Go to **App settings > Publish > Snapcraft** to configure publishing to the Snapcraft Snap Store.  
+1. Go to **App settings > Distribution > Snapcraft** to configure publishing to the Snapcraft Snap Store.  
 2. Upload your Snapcraft login credentials file. This can be created by running the following command locally.
 
 ```


### PR DESCRIPTION
- Replace references to the Publish section with Distribution (for code signing and stores) or Notifications (email or Slack)
- Rename the Publishing category to Distribution and notifications