### PR TITLE
Specify android paths

### DIFF
--- a/content/getting-started/building-a-flutter-app.md
+++ b/content/getting-started/building-a-flutter-app.md
@@ -133,8 +133,8 @@ workflows:
         script: |
           cd . && flutter build apk --release --build-name=1.0.0 --build-number=$(($(google-play get-latest-build-number --package-name "$PACKAGE_NAME" --tracks="$GOOGLE_PLAY_TRACK") + 1))
     artifacts:
-      - build/**/outputs/**/*.apk
-      - build/**/outputs/**/*.aab
+      - build/**/outputs/apk/**/*.apk
+      - build/**/outputs/bundle/**/*.aab
       - build/**/outputs/**/mapping.txt
       - flutter_drive.log
     publishing:

--- a/content/getting-started/yaml.md
+++ b/content/getting-started/yaml.md
@@ -98,7 +98,7 @@ workflows:
     scripts:
       - ...
     artifacts:
-      - build/**/outputs/**/*.aab
+      - build/**/outputs/bundle/**/*.aab
     publishing:
       email:
         recipients:
@@ -290,8 +290,8 @@ Configure the paths and names of the artifacts you would like to use in the foll
 
 ```yaml
 artifacts:
-  - build/**/outputs/**/*.apk                   # relative path for a project in root directory
-  - subfolder_name/build/**/outputs/**/*.apk    # relative path for a project in subfolder
+  - build/**/outputs/apk/**/*.apk                   # relative path for a project in root directory
+  - subfolder_name/build/**/outputs/apk/**/*.apk    # relative path for a project in subfolder
   - build/**/outputs/**/*.aab
   - build/**/outputs/**/mapping.txt
   - build/ios/ipa/*.ipa


### PR DESCRIPTION
Flutter for some reason copies the identical apk to multiple folders - thus with the paths we recommend currently, we export three artefacts with the same name, which is confusing for the users (the md5 checksum is the same - meaning they literally are identical). The change to export more specific paths is already deployed live. 

<img width="417" alt="Screenshot 2021-07-15 at 15 05 15" src="https://user-images.githubusercontent.com/56921374/125801737-d3aea149-a32a-4f07-9139-a7dc608da988.png">


