### PR TITLE
Update yaml-getting-started.md

### DIFF
--- a/content/yaml/yaml-getting-started.md
+++ b/content/yaml/yaml-getting-started.md
@@ -252,7 +252,7 @@ environment:
 
 {{<notebox>}}
 
-Caching `$HOME/Library/Developer/Xcode/DerivedData` won't help speed up iOS builds with Xcode 10.2 or later.
+Caching `$HOME/Library/Developer/Xcode/DerivedData` won't help speed up iOS builds with Xcode 10.2 or later. Codemagic doesn't support caching symlinks.
 
 {{</notebox>}}
 

--- a/content/yaml/yaml-getting-started.md
+++ b/content/yaml/yaml-getting-started.md
@@ -252,7 +252,7 @@ environment:
 
 {{<notebox>}}
 
-Caching `$HOME/Library/Developer/Xcode/DerivedData` won't help speed up iOS builds with Xcode 10.2 or later. Codemagic doesn't support caching symlinks.
+Caching `$HOME/Library/Developer/Xcode/DerivedData` won't help speed up iOS builds with Xcode 10.2 or later.
 
 {{</notebox>}}
 
@@ -262,6 +262,10 @@ cache:
     - ~/.gradle/caches
     - ...
 ```
+{{<notebox>}}
+Note: Codemagic doesn't support caching symlinks.
+{{</notebox>}}
+
 
 ### Triggering
 


### PR DESCRIPTION
Cache Section: We should mention that we do not support caching symlinks.