### PR TITLE
Add docs about iOS device registration

### DIFF
--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -308,16 +308,18 @@ const toggleCategory = ({ target }) => {
 
 // Make sure category with active item is open
 const openActiveCategory = () => {
-    const activeLink = document.querySelector('[js-docs-link].active')
-    const parent = activeLink.closest('[js-docs-menu-item]')
-    if (parent) {
-        const name = parent.querySelector('[js-category-name]')
-        const posts = parent.querySelector('[js-category-posts]')
-        parent.classList.add('open')
-        name.classList.add('open')
-        posts.classList.add('open')
-        posts.style.display = 'block'
-    }
+    const activeLinks = document.querySelectorAll('[js-docs-link].active')
+    activeLinks.forEach((activeLink) => {
+        const parent = activeLink.closest('[js-docs-menu-item]')
+        if (parent) {
+            const name = parent.querySelector('[js-category-name]')
+            const posts = parent.querySelector('[js-category-posts]')
+            parent.classList.add('open')
+            name.classList.add('open')
+            posts.classList.add('open')
+            posts.style.display = 'block'
+        }
+    })
 }
 
 // On ready

--- a/config.yaml
+++ b/config.yaml
@@ -135,6 +135,9 @@ menu:
         - identifier: notes
           params:
               hide: true
+        - identifier: custom-menu-position
+          params:
+              hide: true
 
     extra:
         - identifier: cli

--- a/content/custom-menu-position/ios-provisioning.md
+++ b/content/custom-menu-position/ios-provisioning.md
@@ -2,7 +2,10 @@
 title: Registering iOS test devices
 description: Automatically add new test devices to Apple Developer Portal
 weight: 4
-aliases:
+slug: ../testing/ios-provisioning
+menuCategories:
+  - flutter-testing
+  - yaml-testing
 ---
 
 To be able to test iOS builds on physical devices outside TestFlight, e.g. by downloading the app artifact from Slack or a [public link](../yaml-publishing/public-dashboards), the test devices have to be registered in Apple Developer Portal and included in the provisioning profile used for code signing the app. Codemagic enables you to send your trusted testers a device registration link to obtain their device UDIDs and automatically add them to the list of devices in Apple Developer Portal.

--- a/content/yaml-testing/ios-provisioning.md
+++ b/content/yaml-testing/ios-provisioning.md
@@ -39,6 +39,6 @@ To delete devices from a tester group, click the pencil icon next to the group t
 
 To delete a tester group, click the bin icon next to the tester group. Deleting the group will also delete all registered devices in the group from Codemagic.
 
-Note that deleting a device or a tester group from Codemagic does not remove the devices from Apple Developer Portal and testers can register new devices until the expiration of the invitation link.
+Note that deleting a device or a tester group from Codemagic does not remove the devices from Apple Developer Portal.
 
 To remove devices from [Apple Developer Portal](https://developer.apple.com/), navigate to **Certificates, Identifiers & Profiles > Devices**, select a device and click **Disable**.

--- a/content/yaml-testing/ios-provisioning.md
+++ b/content/yaml-testing/ios-provisioning.md
@@ -1,0 +1,44 @@
+---
+title: Registering iOS test devices
+description: Automatically add new test devices to Apple Developer Portal
+weight: 4
+aliases:
+---
+
+To be able to test iOS builds on physical devices outside TestFlight, e.g. by downloading the app artifact from Slack or a [public link](../yaml-publishing/public-dashboards), the test devices have to be registered in Apple Developer Portal and included in the provisioning profile used for code signing the app. Codemagic enables you to send your trusted testers a device registration link to obtain their device UDIDs and automatically add them to the list of devices in Apple Developer Portal.
+
+{{<notebox>}}
+This feature is available for [teams](../teams/teams) only.
+{{</notebox>}}
+
+## Requirements
+
+* You have to be a team owner to manage iOS test devices. 
+* The **Apple Developer Portal integration** must be connected in **Team integrations** to be able to register new devices. This requires creating an App Store Connect API key with **Developer** permissions, see how to create one [here](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api).
+
+## Creating a tester group
+
+1. Navigate to **Teams > Your team > iOS test devices**.
+2. Click **Create tester group**. A popup window appears with details about the tester group.
+3. Enter the **Tester group name**. All the devices registered from this invitation will be added to this group in Codemagic.
+4. Select the **Developer Portal API key**. The API key determines under which Apple Developer Portal account the devices will be registered.
+5. Then enter the **Tester email addresses** that will receive the device registration link. Note that you can later send new invitations to add more devices to this group.
+6. Finally, click **Send registration link**. 
+
+To add devices to an existing group, find the group in the **Tester groups** section and click **Add new devices**. 
+
+## Device registration
+
+Your testers will receive an email with instructions to register a device. The registration link in email invitation is valid for 7 days.
+
+The email contains a QR code and the **Register device** button to download a configuration profile that must be installed on the device. The configuration profile collects the device UDID and forwards it to Codemagic for registration. On successful registration, the device will be added to Apple Developer Portal and listed in the tester group in Codemagic.
+
+## Deleting test devices and groups
+
+To delete devices from a tester group, click the pencil icon next to the group to edit it and select the devices to be removed. 
+
+To delete a tester group, click the bin icon next to the tester group. Deleting the group will also delete all registered devices in the group from Codemagic.
+
+Note that deleting a device or a tester group from Codemagic does not remove the devices from Apple Developer Portal and testers can register new devices until the expiration of the invitation link.
+
+To remove devices from [Apple Developer Portal](https://developer.apple.com/), navigate to **Certificates, Identifiers & Profiles > Devices**, select a device and click **Disable**.

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -14,6 +14,7 @@
   {{ $title := .Title}}
   {{ $menuItems := .Site.Menus.main }}
   {{ $linkParts := (split (substr .RelPermalink 1 -1) "/") }}
+  {{ $params := .Params}}
   {{ range $index, $part := $linkParts }}
     {{ if lt $index (sub (len $linkParts) 1) }}
       {{ if hasPrefix $part "flutter" }}
@@ -22,6 +23,9 @@
         <span>.YAML</span>
       {{ end }}
       {{ if and (ne $part "yaml") (ne $part "flutter") (ne $part "notes") (ne $part "cli") }}
+        {{ if $params.menuCategories }}
+          <span>{{ humanize $part }}</span>
+        {{ end }}
         {{ template "getCategoryName" ( dict "menuItems" $menuItems "target" $part ) }}
       {{ end }}
     {{ else }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,3 +1,15 @@
+{{ define "page-link"}}
+    {{ $activePage := .activePage}}
+    {{ $page := .page}}
+    <a
+        js-docs-link
+        class="{{ if eq $activePage $page }}active{{ end }}"
+        href="{{ $page.RelPermalink }}"
+        {{if $page.Params.platform}}data-js-platform-specific="{{$page.Params.platform}}"{{end}}>
+        {{ $page.Title }}
+    </a>
+{{ end }}
+
 {{ define "main-menu" }}
     {{ $currentPage := .currentPage}}
     {{ $collapsible := .collapsible}}
@@ -13,7 +25,7 @@
                         js-category-name
                         data-category-id="{{ .Identifier }}"
                         {{if $collapsible}}js-category-toggle{{end}}
-                        {{ if $currentPage.HasMenuCurrent "main" . }}js-open{{ end }}
+                        {{ if or ($currentPage.HasMenuCurrent "main" .) (in $currentPage.Params.menuCategories .Identifier) }}js-open{{ end }}
                     >
                         {{if or (eq .Name "Flutter workflow editor") (eq .Name "Codemagic.yaml")}}Configuration{{else}}{{.Name}}{{end}}
                     </div>
@@ -22,13 +34,16 @@
                             {{ template "main-menu" ( dict "menuItems" .Children "currentPage" $currentPage "collapsible" true ) }}
                         {{ end }}
                         {{ range where site.Pages "Section" .Identifier }}
-                            <a
-                                js-docs-link
-                                class="{{ if eq $currentPage . }}active{{ end }}"
-                                href="{{ .RelPermalink }}"
-                                {{if .Page.Params.platform}}data-js-platform-specific="{{.Page.Params.platform}}"{{end}}>
-                                {{ .Title }}
-                            </a>
+                            {{ template "page-link" (dict "page" . "activePage" $currentPage ) }}
+                        {{ end }}
+                        {{ range where site.Pages "Section" "in" .Params.menuCategories }}
+                            {{ template "page-link" (dict "page" . "activePage" $currentPage ) }}
+                        {{ end }}
+                        {{ $identifier := .Identifier}}
+                        {{ range where site.Pages "Section" "custom-menu-position" }}
+                            {{ if in .Params.menuCategories $identifier }}
+                                {{ template "page-link" (dict "page" . "activePage" $currentPage ) }}
+                            {{ end }}
                         {{ end }}
                     </div>
                 </div>


### PR DESCRIPTION
- Added a new page: iOS device registration. It's currently available in the Testing category in Yaml view only.