### PR TITLE
add "include" shortcode

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,8 @@ params:
     googleOptimizeId: 'GTM-M67KWVX'
     pageRepoCommitPrefix: 'https://github.com/codemagic-ci-cd/codemagic-docs/commit/'
     pageRepoEditPrefix: 'https://github.com/codemagic-ci-cd/codemagic-docs/edit/master/content/'
+    ignorefiles:
+        - /content/partials/*
 imaging:
     resampleFilter: linear
     quality: 90

--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -1,0 +1,1 @@
+{{ $file := .Get 0 }} {{ $page := .Site.GetPage $file }} {{ with $page }} {{ .Content }} {{ end }}


### PR DESCRIPTION
If you need to have some content in multiple files without duplicating, you can create a file in `/content/partials/` and use the content of this file in other markdown files with `include` shortcode.

### Example:

File: `/content/partials/a.md`
Include it as `{{< include "/partials/a.md" >}}`

### Note

If it's a markdown file, it should start with 
```
---
---
```
Don't put partial content files to other directories. Or if you do so, include them to `ignorefiles` in config.