### PR TITLE
fix firebase project instruction

### DIFF
--- a/content/yaml-testing/firebase-test-lab.md
+++ b/content/yaml-testing/firebase-test-lab.md
@@ -28,7 +28,7 @@ Then import the group to `codemagic.yaml` this way:
 ```yaml
 environment:
   groups:
-    - firebase_credentials # <-- (Includes: GCLOUD_KEY_FILE - service account JSON key file, FIREBASE_PROJECT - your Firebase Project Name)
+    - firebase_credentials # <-- (Includes: GCLOUD_KEY_FILE - service account JSON key file, FIREBASE_PROJECT - your Firebase Project ID)
 ```
 Then, add the scripts to run tests on the preferred platform and device. The testing step should come after build scripts.
 


### PR DESCRIPTION
Firebase project ID should be provided not the project name to `FIREBASE_PROJECT` environment variable
Otherwise, the following error will be thrown in Codemagic build
```console
+ gcloud --quiet config set project Triage-Companion
ERROR: (gcloud.config.set) The project property must be set to a valid project ID, not the project name [Triage-Companion]
To set your project, run:

  $ gcloud config set project PROJECT_ID

or to unset it, run:

  $ gcloud config unset project
```