### PR TITLE
Developer role does not have access to upload to store

### DIFF
--- a/content/flutter-code-signing/ios-code-signing.md
+++ b/content/flutter-code-signing/ios-code-signing.md
@@ -56,7 +56,7 @@ It is recommended to create a dedicated App Store Connect API key for Codemagic 
 
 1. Log in to App Store Connect and navigate to **Users and Access > Keys**.
 2. Click on the + sign to generate a new API key.
-3. Enter the name for the key and select an access level. We recommend choosing `App Manager` since `Developer` does not have the required permissions to upload to the store, read more about Apple Developer Program role permissions [here](https://help.apple.com/app-store-connect/#/deve5f9a89d7).
+3. Enter the name for the key and select an access level. We recommend choosing `App Manager`, considering that `Developer` does not have the required permissions to upload to the store. Read more about Apple Developer Program role permissions [here](https://help.apple.com/app-store-connect/#/deve5f9a89d7).
 4. Click **Generate**.
 5. As soon as the key is generated, you can see it added to the list of active keys. Click **Download API Key** to save the private key for later. Note that the key can only be downloaded once.
 


### PR DESCRIPTION
Hi, 

I tried setting up a new project with auto code singing, using a key with a `Developer` role and I got this error:
```
Upload "/Users/builder/clone/build/ios/ipa/eldorado.ipa" to App Store Connect
{
    "tool-version": "4.059.1219",
    "tool-path": "/Applications/Xcode-13.0.app/Contents/SharedFrameworks/ContentDeliveryServices.framework/Versions/A/Frameworks/AppStoreService.framework",
    "os-version": "11.6.0",
    "product-errors": [
        {
            "message": "Unable to authenticate.",
            "userInfo": {
                "NSLocalizedDescription": "Unable to authenticate.",
                "NSLocalizedFailureReason": "Unable to authenticate."
            },
            "code": -19209
        }
    ]
}
```

Then I created a second key with `App Manager` and it worked.

Don't merge PR yet, please, can someone else confirm this?