### PR TITLE
Fix snapcraft build yaml config

### DIFF
--- a/content/yaml-quick-start/building-a-snap-package.md
+++ b/content/yaml-quick-start/building-a-snap-package.md
@@ -29,6 +29,7 @@ workflows:
     name: Snapcraft Build
     instance_type: linux
     environment:
+      vars:
         SNAPCRAFT_BUILD_ENVIRONMENT: host
     scripts:
       - name: Create a snap


### PR DESCRIPTION
The Snapcraft Build environment vars isn't properly defined:

```yaml
workflows:
  snap-build:
    name: Snapcraft Build
    instance_type: linux
    environment:
        SNAPCRAFT_BUILD_ENVIRONMENT: host
    scripts:
      - name: Create a snap
        script: snapcraft snap --output flutter-codemagic-example.snap
    artifacts:
        - '**/*.snap'
```

It is missing`vars`. Fixed to this:
```yaml
workflows:
  snap-build:
    name: Snapcraft Build
    instance_type: linux
    environment:
      vars:
        SNAPCRAFT_BUILD_ENVIRONMENT: host
    scripts:
      - name: Create a snap
        script: snapcraft snap --output flutter-codemagic-example.snap
    artifacts:
        - '**/*.snap'
```