### PR TITLE
Remove Python script from Unity docs

### DIFF
--- a/content/yaml-quick-start/building-a-unity-app.md
+++ b/content/yaml-quick-start/building-a-unity-app.md
@@ -420,8 +420,8 @@ workflows:
       scripts:
         - name: Deactivate Unity License
           script: $UNITY_BIN -batchmode -quit -returnlicense -nographics
-        google_play:
-          # See the following link for information regarding publishing to Google Play - https://docs.codemagic.io/publishing-yaml/distribution/#google-play
-          credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
-          track: alpha   # Any default or custom track    
+      google_play:
+        # See the following link for information regarding publishing to Google Play - https://docs.codemagic.io/publishing-yaml/distribution/#google-play
+        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        track: alpha   # Any default or custom track    
 ```


### PR DESCRIPTION
To simplify set up, the Unity activation, exporting of the iOS or Android project and license return is now done in the codemagic.yaml instead of an external Python script. 

Also, removed references to building for Windows desktop as these docs are currently for mobile platforms.