### PR TITLE
Add alias to keep old links working

### DIFF
--- a/content/yaml-publishing/app-store-connect.md
+++ b/content/yaml-publishing/app-store-connect.md
@@ -2,7 +2,9 @@
 title: App Store Connect
 description: How to deploy an app to App Store and TestFlight using codemagic.yaml
 weight: 1
-aliases: '/publishing-yaml/distribution/'
+aliases: 
+  - '/publishing-yaml/distribution/' 
+  - '/yaml-publishing/distribution/'
 ---
 
 


### PR DESCRIPTION
https://docs.codemagic.io/yaml-publishing/distribution/#app-store-connect was broken as the link wasn't aliased. 