### PR TITLE
Add emulator.wtf integration docs

### DIFF
--- a/content/yaml-testing/emulator-wtf.md
+++ b/content/yaml-testing/emulator-wtf.md
@@ -1,0 +1,76 @@
+---
+title: Testing with emulator.wtf
+description: How to run tests using emulators from emulator.wtf
+weight: 2
+---
+
+## Configuring emulator.wtf API token
+
+You'll need your [emulator.wtf](https://emulator.wtf) API token handy. Add the token with the name `EW_API_TOKEN` into the **Environment variables** in Codemagic UI, either under [Apps](https://codemagic.io/apps) or [Teams](https://codemagic.io/teams). Name the group `emulatorwtf`.
+
+You can then import the token with the following under your workflow:
+
+```yaml
+workflows:
+  android-build:
+    environment:
+      groups:
+        - emulatorwtf # adds EW_API_TOKEN to the workflow
+```
+
+## Running tests
+
+Add the following snippet under your workflow _after_ the Gradle build step. Update the `--app` and `--test` paths according to your build if necessary.
+
+```yaml
+- name: Test
+  script: |
+    ew-cli \
+      --app app/build/outputs/apk/debug/app-debug.apk \
+      --test app/build/outputs/apk/androidTest/app-debug-androidTest.apk \
+      --outputs-dir results
+  test_report: results/**/*.xml
+```
+
+## Capturing logcat
+
+Add the following to your workflow to capture logcat output from the emulator during the test run:
+
+```
+artifacts:
+  - results/**/logcat.txt
+```
+
+## Running tests with coverage
+
+Add `--with-coverage` to the `ew-cli` script to capture coverage during the test run:
+
+```yaml
+- name: Test
+  script: |
+    ew-cli \
+      --app app/build/outputs/apk/debug/app-debug.apk \
+      --test app/build/outputs/apk/androidTest/app-debug-androidTest.apk \
+      --with-coverage \
+      --outputs-dir results
+  test_report: results/**/*.xml
+```
+
+## Running tests in parallel
+
+Add `--num-shards <NUMBER>` to run tests in parallel shards, here's an example to shard tests to 4:
+
+```yaml
+- name: Test
+  script: |
+    ew-cli \
+      --app app/build/outputs/apk/debug/app-debug.apk \
+      --test app/build/outputs/apk/androidTest/app-debug-androidTest.apk \
+      --num-shards 4 \
+      --outputs-dir results
+  test_report: results/**/*.xml
+```
+
+## Further information
+
+There are more options available like pulling directories from the emulator after tests have finished, running on various device models, etc. Check the [emulator.wtf docs](https://emulator.wtf) for more `ew-cli` options to customize your test run.


### PR DESCRIPTION
[emulator.wtf](https://emulator.wtf) is a cloud Android emulator laser-focused on performance, delivering 2-5x gains over alternatives like Firebase Test Lab.

Add documentation on how to run instrumentation tests with [emulator.wtf](https://emulator.wtf).

NOTE: do not merge until `ew-cli` is available on the build machines.