### PR TITLE
Update iOS Simulator to 15.4

### DIFF
--- a/content/yaml-quick-start/building-a-native-ios-app.md
+++ b/content/yaml-quick-start/building-a-native-ios-app.md
@@ -66,7 +66,7 @@ workflows:
                 pod install
             - name: Build ipa for distribution
               script: |
-                xcodebuild build -workspace "$XCODE_WORKSPACE" -scheme "$XCODE_SCHEME" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12 Pro,OS=14.5' -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO 
+                xcodebuild build -workspace "$XCODE_WORKSPACE" -scheme "$XCODE_SCHEME" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12 Pro,OS=15.4' -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO 
         artifacts:
             - /tmp/xcodebuild_logs/*.log
             - $HOME/Library/Developer/Xcode/DerivedData/**/Build/**/*.app


### PR DESCRIPTION
Small developer experience improvement while copying the command from the docs so that developers do not have to update 14.5 to 15.4 as `latest`, `edge` has iOS 15.4 simulators.