### PR TITLE
Feature: default Flutter version

### DIFF
--- a/content/flutter-testing/testing-widgets.md
+++ b/content/flutter-testing/testing-widgets.md
@@ -14,4 +14,4 @@ To test widgets, the following is required:
 
 Your widget repository is detected automatically like any other repository, but there are differences in the build process. Technically, Codemagic will only fetch the sources, install the dependencies and run the tests. If there are failing tests, you will receive the test report in your email.
 
-After the first build, you can change the Flutter version (by default, it's `channel Stable`) and configure email publishing and Slack for receiving status reports.
+After the first build, you can change the Flutter version and configure email publishing and Slack for receiving status reports.


### PR DESCRIPTION
We introduce a default Flutter version for our build machines. Currently default will be resolved to
* 3.0.0 for all Xcode 13+ machines, Linux, and Windows
* 2.10.5 for Xcode 11 and Xcode 12 machines

The default version will be used if Flutter version is not specified (before it was stable) and should be recommended for all non-Flutter projects.

Also we changed the logic behind stable version. Now, it always matches the official Flutter stable channel. If the version is not pre-installed on a builder machine, it will be downloaded automatically.