### PR TITLE
Add "markdown" shortcode

### DIFF
--- a/layouts/shortcodes/markdown.html
+++ b/layouts/shortcodes/markdown.html
@@ -1,0 +1,3 @@
+<div>
+    {{ .Inner | markdownify }}
+</div>


### PR DESCRIPTION
Enables using markdown within nested dynamic tabs. A simple copy of the "notebox" shortcode but without setting class.