### PR TITLE
Add border-bottom underline to the active tab

### DIFF
--- a/assets/scss/modules/_tabbed-pane.scss
+++ b/assets/scss/modules/_tabbed-pane.scss
@@ -55,7 +55,7 @@
                 cursor: default;
                 background-color: #ffffff;
                 border: 1px solid $grey-l;
-                border-bottom-color: transparent;
+                border-bottom: 3px solid $magenta;
             }
         }
     }


### PR DESCRIPTION
Just an idea to make the active tab more prominently visible by using an underline in our brand color (magenta)