### PR TITLE
Add comments to markdown shortcode

### DIFF
--- a/layouts/shortcodes/markdown.html
+++ b/layouts/shortcodes/markdown.html
@@ -1,3 +1,12 @@
+<!-- Produces weird results when used on a single paragraph. -->
+<!-- Workaround is to add another dummy paragraph. E.g.: -->
+
+<!--  /{/{/< markdown />/}/}                    -->
+<!--  Some text in a single paragraph.          -->
+<!--                                            -->
+<!--  &nbsp;                                    -->
+<!--  /{/{/< //markdown />/}/}                  -->
+
 <div>
     {{ .Inner | markdownify }}
 </div>


### PR DESCRIPTION
Markdown shortcode does not properly create paragraphs if it wraps only a single paragraph of text. Adding another paragraph, even if it's an empty one is a passable workaround.