### PR TITLE
fix a typo

### DIFF
--- a/content/partials/build-versioning-android.md
+++ b/content/partials/build-versioning-android.md
@@ -7,7 +7,7 @@ You can find the full sample project with the instructions on alternative ways t
 
 
 The prerequisite is a valid **Google Cloud Service Account**. Plese follow these steps:
-1. Go to [this guide](../knowledge-base/google-services-authentication.md) and complete the steps in the **Google Play** section.
+1. Go to [this guide](../knowledge-base/google-services-authentication) and complete the steps in the **Google Play** section.
 2. Skip to the **Creating a service account** section in the same guide and complete those steps also.
 3. You now have a `JSON` file with the credentials.
 4. Open Codemagic UI and create a new Environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`.

--- a/content/partials/code-signing-android.md
+++ b/content/partials/code-signing-android.md
@@ -50,7 +50,7 @@ Modify your **`android/app/build.gradle`** as follows:
 
 #### Configuring Environment variables
 
-The environment variables referenced by the `build.gradle` need to be stored in the Codemagic UI. A detailed explanation on how Environment variables and groups work can be found [here](../variables/environment-variable-groups.md).
+The environment variables referenced by the `build.gradle` need to be stored in the Codemagic UI. A detailed explanation on how Environment variables and groups work can be found [here](../variables/environment-variable-groups).
 
 The keystore file, like all binary files, has to be base64 encoded before storing its value.
 

--- a/content/partials/code-signing-ios.md
+++ b/content/partials/code-signing-ios.md
@@ -63,7 +63,7 @@ openssl pkcs12 -in IOS_DISTRIBUTION.p12 -nodes -nocerts | openssl rsa -out ios_d
 
 9. Run the following command on the **App Store Connect API key** file that you downloaded earlier (in our example saved as `codemagic_api_key.p8`) to copy its content to clipboard:
 {{< highlight Shell "style=rrt">}}
-cat codemagic_api_key.p8 | base64 | pbcopy
+cat codemagic_api_key.p8 | pbcopy
 {{< /highlight >}}
 
 10. Create a new Environment variable `APP_STORE_CONNECT_PRIVATE_KEY` and paste the value from clipboard.

--- a/content/partials/code-signing-ios.md
+++ b/content/partials/code-signing-ios.md
@@ -9,7 +9,7 @@ Signing iOS applications requires [Apple Developer Program](https://developer.ap
 2. Use the **automatic code signing** option where Codemagic takes care of code signing and signing files management on your behalf.
 
 
-More details about iOS app codesigning can be found [here](../yaml-code-signing/signing-ios.md).
+More details about iOS app codesigning can be found [here](../yaml-code-signing/signing-ios).
 
 #### Creating the App Store Connect API key
 
@@ -17,7 +17,7 @@ More details about iOS app codesigning can be found [here](../yaml-code-signing/
 
 #### Creating the iOS Distribution Certificate
 
-The following steps describe one way of creating an iOS Distribution Certificate. This method requires a Mac computer and the certificate will be stored on it for easier retrieval in future. For a more detailed explanation and alternative certificate generation methods, please visit [here](../yaml-code-signing/signing-ios.md).
+The following steps describe one way of creating an iOS Distribution Certificate. This method requires a Mac computer and the certificate will be stored on it for easier retrieval in future. For a more detailed explanation and alternative certificate generation methods, please visit [here](../yaml-code-signing/signing-ios).
 
 1. On your Mac, open the **Keychain Access**, located in the **Applications and Utilities** folder.
 2. From the upper menu, open **Preferences**

--- a/content/partials/create-yaml-intro.md
+++ b/content/partials/create-yaml-intro.md
@@ -2,7 +2,7 @@
 ---
 
 ## Creating codemagic.yaml
-In order to use `codemagic.yaml` for build configuration on Codemagic, it has to be committed to your repository. The name of the file must be `codemagic.yaml` and it must be located in the root directory of the repository. Detailed explanation can be found [here](../yaml/yaml-getting-started.md).
+In order to use `codemagic.yaml` for build configuration on Codemagic, it has to be committed to your repository. The name of the file must be `codemagic.yaml` and it must be located in the root directory of the repository. Detailed explanation can be found [here](../yaml/yaml-getting-started).
 
 {{<notebox>}}
 **Tip**

--- a/content/partials/publishing-android-ios.md
+++ b/content/partials/publishing-android-ios.md
@@ -2,7 +2,7 @@
 ---
 
 Codemagic offers a wide array of options for app publishing and the list of partners and integrations is continuously growing. For the most up-to-date information, check the guides in the **Configuration > Publishing** section of these docs.
-To get more details on the publishing options presented in this guide, please check the [Email publishing](../yaml-publishing/email.md), the [Google Play Store](../yaml-publishing/google-play.md) publishing and the [App Store Connect](../yaml-publishing/app-store-connect.md).
+To get more details on the publishing options presented in this guide, please check the [Email publishing](../yaml-publishing/email), the [Google Play Store](../yaml-publishing/google-play) publishing and the [App Store Connect](../yaml-publishing/app-store-connect).
 
 #### Email publishing
 If the build finishes successfully, release notes (if passed), and the generated artifacts will be published to the provided email address(es). If the build fails, an email with a link to build logs will be sent.

--- a/content/yaml-quick-start/building-a-react-native-app.md
+++ b/content/yaml-quick-start/building-a-react-native-app.md
@@ -273,7 +273,7 @@ scripts:
 
 ## Build versioning
 
-If you are going to publish your app to App Store Connect or Google Play, each uploaded artifact must have a new version satisfying each app store’s requirements. Codemagic allows you to easily automate this process and increment the version numbers for each build. For more information and details, see [here](../configuration/build-versioning.md).
+If you are going to publish your app to App Store Connect or Google Play, each uploaded artifact must have a new version satisfying each app store’s requirements. Codemagic allows you to easily automate this process and increment the version numbers for each build. For more information and details, see [here](../configuration/build-versioning).
 
 
 {{< tabpane >}}
@@ -444,8 +444,8 @@ workflows:
 ## Next steps
 While this basic workflow configuration is incredibly useful, it is certainly not the end of the road and there are numerous advanced actions that Codemagic can help you with.
 
-We encourage you to investigate [Running tests with Codemagic](../yaml-testing/testing.md) to get you started with testing, as well as additional guides such as the one on running tests on [Firebase Test Lab](../yaml-testing/firebase-test-lab.md) or [Registering iOS test devices](../custom-menu-position/ios-provisioning.md).
+We encourage you to investigate [Running tests with Codemagic](../yaml-testing/testing) to get you started with testing, as well as additional guides such as the one on running tests on [Firebase Test Lab](../yaml-testing/firebase-test-lab) or [Registering iOS test devices](../custom-menu-position/ios-provisioning).
 
-Documentation on [Using codemagic.yaml](../yaml/yaml-getting-started.md) teaches you to configure additional options such as [changing the instance type](../yaml-getting-started/#instance-type) on which to build, speeding up builds by configuring [Caching options](../yaml-getting-started/#instance-type#cache), or configuring builds to be [automatically triggered](../yaml-getting-started/#triggering) on repository events.
+Documentation on [Using codemagic.yaml](../yaml/yaml-getting-started) teaches you to configure additional options such as [changing the instance type](../yaml-getting-started/#instance-type) on which to build, speeding up builds by configuring [Caching options](../yaml-getting-started/#instance-type#cache), or configuring builds to be [automatically triggered](../yaml-getting-started/#triggering) on repository events.
 
 ---


### PR DESCRIPTION
API connect key does not need base64 encoding