### PR TITLE
Correct path to local.properties

### DIFF
--- a/content/yaml-quick-start/building-a-react-native-app.md
+++ b/content/yaml-quick-start/building-a-react-native-app.md
@@ -187,7 +187,7 @@ scripts:
     npm install
   - name: Set Android SDK location
     script: |
-   echo "sdk.dir=$ANDROID_SDK_ROOT" > "$CM_BUILD_DIR/android/local.properties"
+   echo "sdk.dir=$ANDROID_SDK_ROOT" > "$CM_BUILD_DIR/local.properties"
   - name: Build Android release
     script: |
    cd android && ./gradlew bundleRelease


### PR DESCRIPTION
The `androd` folder caused a build error when I followed the guide

```
Set Android SDK location

/var/folders/m7/h1mg7c7x40ddjz6mxjxm3htr0000gn/T/build_script_6_1_q6yej6s1: line 3:  /Users/builder/clone/android/local.properties: No such file or directory  
```