### PR TITLE
Added build script for Windows to Unity docs

### DIFF
--- a/content/yaml-quick-start/building-a-unity-app.md
+++ b/content/yaml-quick-start/building-a-unity-app.md
@@ -189,6 +189,20 @@ public static class BuildScript
         Debug.Log("Built iOS");
     }
 
+    [MenuItem("Build/Build Windows")]
+    public static void BuildWindows()
+    {
+        BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions();
+        buildPlayerOptions.locationPathName = "win/" + Application.productName + ".exe";
+        buildPlayerOptions.target = BuildTarget.StandaloneWindows;
+        buildPlayerOptions.options = BuildOptions.None;
+        buildPlayerOptions.scenes = GetScenes();
+
+        Debug.Log("Building Windows");
+        BuildPipeline.BuildPlayer(buildPlayerOptions);
+        Debug.Log("Built Windows");
+    }
+
     private static string[] GetScenes()
     {
         return (from scene in EditorBuildSettings.scenes where scene.enabled select scene.path).ToArray();


### PR DESCRIPTION
Previously the build script only had items for Android and iOS. I think it's worth adding workflows for Windows there as well. Maybe there are other parts of the Codemagic Unity docs that we need to pay attention to, but the build script is obviously missing. Borrowed one from an upcoming article by Mina.