### PR TITLE
Add docs contribution information

### DIFF
--- a/assets/scss/_article.scss
+++ b/assets/scss/_article.scss
@@ -308,3 +308,4 @@
 @import './modules/toc';
 @import './modules/sidebar';
 @import './modules/help-footer';
+@import './modules/contribute-footer';

--- a/assets/scss/modules/_contribute-footer.scss
+++ b/assets/scss/modules/_contribute-footer.scss
@@ -1,0 +1,18 @@
+#contribute-footer {
+    margin: 0px;
+    display: grid;
+    grid-template-columns: 1fr 200px;
+    align-items: center;
+    gap: 50px;
+
+    h2 {
+        font-size: 20px;
+        margin: 0 0 1em;
+    }
+    p {
+        margin: 1em 0;
+    }
+    .content {
+        padding: 0px 0 10px 0 ;
+    }
+}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -29,7 +29,9 @@
                 <main js-article>
                     {{ block "main" . }}{{ end }}
                     <!---->
+                    
                     {{ partial "help-footer" }}
+                    {{ partial "contribute-footer" }}
                 </main>
                 <footer id="footer">{{ partial "footer" . }}</footer>
             </div>

--- a/layouts/partials/contribute-footer.html
+++ b/layouts/partials/contribute-footer.html
@@ -1,0 +1,26 @@
+<div id="contribute-footer">
+    <div class="content">
+        <h2>Contributing to the documentation</h2>
+        <p>
+            Codemagic's documentation is open source and availble on <a href="https://github.com/codemagic-ci-cd/codemagic-docs/" target="_blank" rel="noopener noreferrer">GitHub.</a>
+        </p>
+        <ul>
+            <li>To contribute to the docs, you can raise a <strong>pull request</strong> as described             
+                <a
+                  href="https://github.com/codemagic-ci-cd/codemagic-docs/blob/master/readme.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >here.
+                </a>
+            </li>
+            <li>To report an <strong>issue</strong> with the documentation, or to give <strong>comments</strong> and <strong>feedback</strong> you can open an issue
+                <a
+                  href="https://github.com/codemagic-ci-cd/codemagic-docs/issues"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >here.
+              </a>
+            </li>
+        </ul>
+    </div>
+</div>    


### PR DESCRIPTION
Add a new section to the footer to make it more obvious how to contribute to the docs and where to raise issues or give feedback about the docs.