### PR TITLE
Fix instructions step for android build versioning

### DIFF
--- a/content/knowledge-codemagic/build-versioning.md
+++ b/content/knowledge-codemagic/build-versioning.md
@@ -290,7 +290,7 @@ scripts:
   - name: Build Android release
     script: | 
       LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME")
-      if [ -z LATEST_BUILD_NUMBER ]
+      if [ -z LATEST_GOOGLE_PLAY_BUILD_NUMBER ]
         then
           # fallback in case no build number was found from Google Play.
           # Alternatively, you can `exit 1` to fail the build

--- a/content/partials/quickstart/build-versioning-android.md
+++ b/content/partials/quickstart/build-versioning-android.md
@@ -27,7 +27,7 @@ scripts:
   - name: Build Android release
     script: | 
       LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME")
-      if [ -z LATEST_BUILD_NUMBER ]; then
+      if [ -z LATEST_GOOGLE_PLAY_BUILD_NUMBER ]; then
         # fallback in case no build number was found from Google Play.
         # Alternatively, you can `exit 1` to fail the build
         # BUILD_NUMBER is a Codemagic built-in variable tracking the number

--- a/content/yaml-quick-start/building-a-kmm-app.md
+++ b/content/yaml-quick-start/building-a-kmm-app.md
@@ -119,7 +119,7 @@ workflows:
       - name: Build Android release
         script: | 
           LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME")
-          if [ -z LATEST_BUILD_NUMBER ]; then
+          if [ -z LATEST_GOOGLE_PLAY_BUILD_NUMBER ]; then
             # fallback in case no build number was found from Google Play.
             # Alternatively, you can `exit 1` to fail the build
             # BUILD_NUMBER is a Codemagic built-in variable tracking the number

--- a/content/yaml-quick-start/building-a-native-android-app.md
+++ b/content/yaml-quick-start/building-a-native-android-app.md
@@ -103,7 +103,7 @@ workflows:
       - name: Build Android release
         script: | 
           LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME")
-          if [ -z LATEST_BUILD_NUMBER ]; then
+          if [ -z LATEST_GOOGLE_PLAY_BUILD_NUMBER ]; then
               # fallback in case no build number was found from google play. Alternatively, you can `exit 1` to fail the build
               UPDATED_BUILD_NUMBER=$BUILD_NUMBER
           else

--- a/content/yaml-quick-start/building-a-react-native-app.md
+++ b/content/yaml-quick-start/building-a-react-native-app.md
@@ -327,7 +327,7 @@ workflows:
       - name: Build Android release
         script: | 
           LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME")
-          if [ -z LATEST_BUILD_NUMBER ]; then
+          if [ -z LATEST_GOOGLE_PLAY_BUILD_NUMBER ]; then
               # fallback in case no build number was found from google play. Alternatively, you can `exit 1` to fail the build
               UPDATED_BUILD_NUMBER=$BUILD_NUMBER
           else

--- a/content/yaml-quick-start/building-an-ionic-app.md
+++ b/content/yaml-quick-start/building-an-ionic-app.md
@@ -160,7 +160,7 @@ workflows:
       - name: Build Android release
         script: | 
           LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME")
-          if [ -z LATEST_BUILD_NUMBER ]; then
+          if [ -z LATEST_GOOGLE_PLAY_BUILD_NUMBER ]; then
             # fallback in case no build number was found from Google Play.
             # Alternatively, you can `exit 1` to fail the build
             # BUILD_NUMBER is a Codemagic built-in variable tracking the number


### PR DESCRIPTION
Documentation https://docs.codemagic.io/yaml-quick-start/building-a-native-android-app/ Build versioning step 7 example has mistake where variable LATEST_BUILD_NUMBER is used instead of LATEST_GOOGLE_PLAY_BUILD_NUMBER.