### PR TITLE
Updating building-a-native-android-app.md, changing artifact path

### DIFF
--- a/content/yaml-quick-start/building-a-native-android-app.md
+++ b/content/yaml-quick-start/building-a-native-android-app.md
@@ -54,7 +54,7 @@ scripts:
       # gradlew assembleRelease # -> to create the .apk
 
 artifacts:
-  - android/app/build/outputs/**/*.aab
+  - app/build/outputs/**/*.aab
 {{< /highlight >}}
 
 ## Build versioning
@@ -111,7 +111,7 @@ workflows:
           fi
           ./gradlew bundleRelease -PversionCode=$UPDATED_BUILD_NUMBER -PversionName=1.0.$UPDATED_BUILD_NUMBER
     artifacts:
-      - android/app/build/outputs/**/*.aab
+      - app/build/outputs/**/*.aab
     publishing:
       email:
         recipients:


### PR DESCRIPTION
Problem: No artifact is generated and is therefore not available for download after the build.

Solution: Change the path
From: - android/app/build/outputs/**/*.aab
to: - app/build/outputs/**/*.aab 

More details:
If you follow the steps in the documentation, no artifact will be created as mentioned above. The following message appears:

"
== Gathering artifacts ==
No artifacts were found
"

If you make the changes I suggested and follow the documentation otherwise, the .aab artifact is created successfully and is then also available for download.

Furthermore, if you look at the sample project from codemagic, the path is also given as I suggested: https://github.com/codemagic-ci-cd/codemagic-sample-projects/blob/main/android/android-espresso-demo-project/codemagic.yaml

Therefore I would suggest to adjust the path also in the documentation so that the artifact is successfully generated during a build.

Thank you for the great work!