### PR TITLE
Updating testing.md fixing wrong indentation for "test_report"

### DIFF
--- a/content/yaml-quick-start/building-a-native-android-app.md
+++ b/content/yaml-quick-start/building-a-native-android-app.md
@@ -54,7 +54,7 @@ scripts:
       # gradlew assembleRelease # -> to create the .apk
 
 artifacts:
-  - app/build/outputs/**/*.aab
+  - android/app/build/outputs/**/*.aab
 {{< /highlight >}}
 
 ## Build versioning
@@ -111,7 +111,7 @@ workflows:
           fi
           ./gradlew bundleRelease -PversionCode=$UPDATED_BUILD_NUMBER -PversionName=1.0.$UPDATED_BUILD_NUMBER
     artifacts:
-      - app/build/outputs/**/*.aab
+      - android/app/build/outputs/**/*.aab
     publishing:
       email:
         recipients:

--- a/content/yaml-quick-start/building-a-native-android-app.md
+++ b/content/yaml-quick-start/building-a-native-android-app.md
@@ -54,7 +54,7 @@ scripts:
       # gradlew assembleRelease # -> to create the .apk
 
 artifacts:
-  - android/app/build/outputs/**/*.aab
+  - app/build/outputs/**/*.aab
 {{< /highlight >}}
 
 ## Build versioning
@@ -111,7 +111,7 @@ workflows:
           fi
           ./gradlew bundleRelease -PversionCode=$UPDATED_BUILD_NUMBER -PversionName=1.0.$UPDATED_BUILD_NUMBER
     artifacts:
-      - android/app/build/outputs/**/*.aab
+      - app/build/outputs/**/*.aab
     publishing:
       email:
         recipients:

--- a/content/yaml-testing/testing.md
+++ b/content/yaml-testing/testing.md
@@ -331,7 +331,7 @@ For non-UI tests or unit tests:
   scripts:
     - name: Test
       script: ./gradlew test
-    test_report: app/build/test-results/**/*.xml
+      test_report: app/build/test-results/**/*.xml
 {{< /highlight >}}
 
 


### PR DESCRIPTION
**Problem:** Indentation of the "test_report" is not correct and leads to a "Configuration file error".

**Solution:** Correct the indentation of the test_report:
From:
 - name: test
      script: ./gradlew test
 test_report: app/build/test-results/**/*.xml
to: 
 - name: test
      script: ./gradlew test
      test_report: app/build/test-results/**/*.xml

**More details:**
The indentation in the yaml file of the "_test_report_" is not correct and therefore leads to a visible "_Configuration file error_" in the yaml overview on the codemagic page itself.

I could only test this with a native Android app, but it's possible that the indentation is also wrong for the other test cases in the documentation (flutter, ..). For "Native macOS" the indentation in the documentation should be correct and is as I suggested.

Exact error message in the codemagic.yaml overview (on codemagic.io):

"
```
Configuration file error:
While parsing a block collection
  in "<byte string>", line 12, column 7:
          - name: set android sdk location
          ^
expected <block end>, but found '?'
  in "<byte string>", line 17, column 7:
          test_report: app/build/test-resu ... 
          ^
```
"

Thanks!