### PR TITLE
Use checkout@v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
             AWS_ACCESS_KEY_ID: AKIAVIULH47FMHXU2IXE
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
             - run: curl --location https://github.com/gohugoio/hugo/releases/download/v0.85.0/hugo_extended_0.85.0_Linux-64bit.tar.gz | tar -vxzO hugo > hugo && chmod a+x hugo


### PR DESCRIPTION
Currently deployment builds have the warning:
```
Node.js 12 actions are deprecated. For more information see: [GitHub Actions: All Actions will begin running on Node16 instead of Node12 | GitHub Changelog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
```

Updating checkout from v2 to v3 solves the issue, using node 16 by default. 
https://github.com/actions/checkout#whats-new