### PR TITLE
Sync docs with behaviour

### DIFF
--- a/content/flutter-testing/static-code-analysis.md
+++ b/content/flutter-testing/static-code-analysis.md
@@ -23,7 +23,11 @@ Codemagic is integrated with [Dart Code Metrics](https://pub.dev/packages/dart_c
 
 By default, Dart Code Metrics is disabled and has to be enabled in **App settings > Tests > Static code analysis** by checking the **Enable Dart Code Metrics** option.
 
-When enabled, `flutter pub global run dart_code_metrics:metrics analyze lib` will be run with each build. You can see the results and the logs of the analysis under the **Running tests** step in build overview.
+When enabled, `flutter pub run dart_code_metrics:metrics analyze lib` will be run with each build. You can see the results and the logs of the analysis under the **Running tests** step in build overview.
+
+{{<notebox>}}
+**Note:** Codemagic will attempt to use the `dart_code_metrics` version defined in your `pubspec.yaml`; if it is not defined, Codemagic will temporarily add the most recent compatible version of `dart_code_metrics` to your dependencies during build time. The minimum compatible version of `dart_code_metrics` is `3.0.0`.
+{{</notebox>}}
 
 ### Stop build if tests or analysis fail
 

--- a/content/flutter-testing/static-code-analysis.md
+++ b/content/flutter-testing/static-code-analysis.md
@@ -23,7 +23,7 @@ Codemagic is integrated with [Dart Code Metrics](https://pub.dev/packages/dart_c
 
 By default, Dart Code Metrics is disabled and has to be enabled in **App settings > Tests > Static code analysis** by checking the **Enable Dart Code Metrics** option.
 
-When enabled, `flutter pub run dart_code_metrics:metrics analyze lib` will be run with each build. You can see the results and the logs of the analysis under the **Running tests** step in build overview.
+When enabled, `flutter pub global run dart_code_metrics:metrics analyze lib` will be run with each build. You can see the results and the logs of the analysis under the **Running tests** step in build overview.
 
 ### Stop build if tests or analysis fail
 

--- a/content/yaml-testing/dart-code-metrics.md
+++ b/content/yaml-testing/dart-code-metrics.md
@@ -40,7 +40,4 @@ scripts:
     test_report: metrics-results/dart_code_metrics.json
 {{< /highlight >}}
 
-
-For Flutter projects it is recommended to replace the dart commands with flutter commands.
-
 If you wish to configure Dart Code Metrics, add an `analysis_options.yaml` file to your project as per the [official documentation](https://dartcodemetrics.dev/docs/getting-started/configuration).


### PR DESCRIPTION
The actual behaviour differs from what is described in the documentation, as the global package is always ran when dart code metrics is enabled.