### PR TITLE
fix macos tab labels for 12.0+ and 12.5

### DIFF
--- a/content/specs/versions-macos.md
+++ b/content/specs/versions-macos.md
@@ -30,11 +30,11 @@ Depending on the Xcode version that you specify in **Build Settings** or in `cod
 {{< include "/partials/specs/versions-macos-xcode-13-0.md" >}}
 {{< /tab >}}
 
-{{< tab header="Xcode 12.4 - 12.5" >}}
+{{< tab header="Xcode 12.5" >}}
 {{< include "/partials/specs/versions-macos-xcode-12-5.md" >}}
 {{< /tab >}}
 
-{{< tab header="Xcode 12.0 - 12.3" >}}
+{{< tab header="Xcode 12.0 - 12.4" >}}
 {{< include "/partials/specs/versions-macos-xcode-12-0.md" >}}
 {{< /tab >}}
 


### PR DESCRIPTION
trello [task](https://trello.com/c/3jMM2rav/1892-confirm-versions-on-xcode-12-images)