### PR TITLE
Update artefact link expiry information

### DIFF
--- a/content/flutter-notification/email-and-slack-notifications.md
+++ b/content/flutter-notification/email-and-slack-notifications.md
@@ -13,7 +13,7 @@ Email publishing settings can be found in **App settings > Notifications > Email
 
 Email publishing is the only publishing option that is enabled by default. Codemagic uses the email specified as the default one in the service you used to log in (Github, Bitbucket, Gitlab). You can add multiple email addresses.
 
-If the build finishes successfully, release notes (if passed), and the generated artifacts will be published to the provided email. The artifact download links in email are valid for 24 hours.
+If the build finishes successfully, release notes (if passed) and the generated artifacts will be published to the provided email. The artifact download links in email are, by default, valid for 24 hours; the lifetime of publicly accessible artifact download links is configurable in **Team settings > Artifact download links**.
 
 If the build fails, you will be sent a link to the build logs. Check the **Publish artifacts even if tests fail** option in the workflow editor to publish artifacts even when one or more tests fail. If that option is unchecked, generated artifacts (if there are any) will be attached only to successful builds.
 
@@ -31,7 +31,7 @@ Once your Slack workspace is connected, you can enable Slack publishing and sele
 
 In order to publish to **private channels**, you need to invite the Codemagic app to the channels, otherwise, the app does not have access to private channels. To invite the Codemagic app to private channels, write `@codemagic` in the channel. If you are in the Codemagic web app, refresh the page, and the new channel will become available in the dropdown menu.
 
-If the build finishes successfully, release notes (if passed), and the generated artifacts will be published to the specified channel. The artifact download links in Slack notifications are valid for 24 hours.
+If the build finishes successfully, release notes (if passed) and the generated artifacts will be published to the specified channel. The artifact download links in Slack notifications are, by default, valid for 24 hours; the lifetime of publicly accessible artifact download links is configurable in **Team settings > Artifact download links**.
 
 If the build fails, a link to the build logs is published. Check **Publish artifacts even if tests fail** to publish artifacts even when one or more tests fail. If the option is unchecked, generated artifacts (if any) will be attached to successful builds only.
 

--- a/content/yaml-notification/email.md
+++ b/content/yaml-notification/email.md
@@ -6,7 +6,7 @@ aliases:
   - /yaml-publishing/email
 ---
 
-If the build finishes successfully, release notes (if passed), and the generated artifacts will be published to the provided email address(es). The artifact download links in email are valid for 24 hours.
+If the build finishes successfully, release notes (if passed) and the generated artifacts will be published to the provided email address(es). The artifact download links in email are, by default, valid for 24 hours; the lifetime of publicly accessible artifact download links is configurable in **Team settings > Artifact download links**.
 
 If the build fails, an email with a link to build logs will be sent.
 

--- a/content/yaml-notification/slack.md
+++ b/content/yaml-notification/slack.md
@@ -30,7 +30,7 @@ The Slack channel for publishing is configured separately for each workflow in t
 **Note:** In order to publish to **private channels**, you need to invite the Codemagic app to the channels; otherwise, the app does not have access to private channels. To invite Codemagic app to private channels, write `@codemagic` in the channel. If the private channel access is restricted by Slack admin rights, it will have to be changed manually, otherwise publishing to that channel will not be possible.
 {{</notebox>}}
 
-If the build finishes successfully, release notes (if passed), and the generated artifacts will be published to the specified channel. The artifact download links in Slack notifications are valid for 24 hours.
+If the build finishes successfully, release notes (if passed) and the generated artifacts will be published to the specified channel. The artifact download links in Slack notifications are, by default, valid for 24 hours; the lifetime of publicly accessible artifact download links is configurable in **Team settings > Artifact download links**.
 
 If the build fails, a link to the build logs is published. When you set `notify_on_build_start` to `true`, the channel will be notified when a build starts.
 

--- a/content/yaml-publishing/build-dashboards.md
+++ b/content/yaml-publishing/build-dashboards.md
@@ -10,6 +10,8 @@ aliases:
 
 Build dashboards make it possible for teams to share the list of team's builds, release notes (if passed) and build artifacts with people outside Codemagic using a public link (build logs will not be exposed). This is a convenient option for distributing builds to testers or sharing build artifacts with stakeholders.
 
+The artifact download links in build dashboards are, by default, valid for 24 hours; the lifetime of publicly accessible artifact download links is configurable in **Team settings > Artifact download links**. Download links are recreated with the configured time on each dashboard refresh.
+
 {{<notebox>}}
 **Note:** The build dashboards feature is available for teams only. It is not possible to create build dashboards for apps on personal accounts.
 {{</notebox>}}

--- a/content/yaml-publishing/build-dashboards.md
+++ b/content/yaml-publishing/build-dashboards.md
@@ -10,7 +10,7 @@ aliases:
 
 Build dashboards make it possible for teams to share the list of team's builds, release notes (if passed) and build artifacts with people outside Codemagic using a public link (build logs will not be exposed). This is a convenient option for distributing builds to testers or sharing build artifacts with stakeholders.
 
-The artifact download links in build dashboards are, by default, valid for 24 hours; the lifetime of publicly accessible artifact download links is configurable in **Team settings > Artifact download links**. Download links are recreated with the configured time on each dashboard refresh.
+The artifact download links in build dashboards are valid for 24 hours. Download links are recreated on each dashboard refresh.
 
 {{<notebox>}}
 **Note:** The build dashboards feature is available for teams only. It is not possible to create build dashboards for apps on personal accounts.


### PR DESCRIPTION
As per the soon-to-be update to the Codemagic product, artifact links published via e-mail or slack will have configurable expiration dates.

This can be merged after the features have been deployed to the product.