### PR TITLE
Machine type changes

### DIFF
--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -27,7 +27,7 @@ The instance types and hardware specifications can be found below.
 | **Item**        | **Specification**                                                                                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | macOS M1 standard VM         | 3.2GHz Quad Core / 8GB                                                                                                                                                 |
-| macOS premium VM         | 3.7GHz Quad Core / 32GB                                                                                                                                                 |
+| macOS Intel VM         | 3.7GHz Quad Core / 32GB                                                                                                                                                 |
 | Linux premium VM         | 8 vCPUs, 32 GB memory                                                                                                                                                 |
 | Linux standard VM        | 4 vCPUs, 16 GB memory                                                 |
 | Windows premium VM       | 8 vCPUs, 32 GB memory  
@@ -48,21 +48,21 @@ When billing is enabled on personal accounts, you will still have **500 free bui
 
 Usage on macOS M1 standard VM that exceeds 500 minutes is charged at rate shown below.
 
-Builds on macOS premium VM, Linux standard VM, and Linux premium VM do not have free build minutes. The per minute pricing for each instance type is shown below.
+Builds on macOS Intel VM, Linux standard VM, and Linux premium VM do not have free build minutes. The per minute pricing for each instance type is shown below.
 
 You will never be charged more than $299/month on this plan.
 
 | **Item**  | **Price**                                                                                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | macOS M1 standard VM         | $0.095 / minute                                                                                                                                                 |
-| macOS premium VM         | $0.095 / minute                                                                                                                                                 |
+| macOS Intel VM         | $0.095 / minute                                                                                                                                                 |
 | Linux premium VM         | $0.045 / minute                                                                                                                                                 |
 | Linux standard VM        | $0.015 / minute                                                                                                                                                 |
 | Windows VM               | $0.045 / minute                                                                                                                                                 |
 
 ### Pricing for Teams
 
-For teams, all build minutes using macOS M1 standard VM, macOS premium VM, Linux standard VM, and Linux premium VM are charged at the rates shown below. 
+For teams, all build minutes using macOS M1 standard VM, macOS Intel VM, Linux standard VM, and Linux premium VM are charged at the rates shown below. 
 
 Each extra build concurrency allows running an additional build in parallel. For example, two extra build concurrencies allow running three builds in parallel. 
 
@@ -75,13 +75,13 @@ You will never be charged more than $299/month on this plan.
 | **Item**  | **Price**                                                                                                                                                       |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | macOS M1 standard VM         | $0.095 / minute                                                                                                                                                 |
-| macOS premium VM         | $0.095 / minute                                                                                                                                                 |
+| macOS Intel VM         | $0.095 / minute                                                                                                                                                 |
 | Linux premium VM         | $0.045 / minute                                                                                                                                                 |
 | Linux standard VM        | $0.015 / minute                                                                                                                                                 |
 | Windows VM               | $0.045 / minute                                                                                                                                                 |                                                                                                              |
 | Extra build concurrency  | $49 / month                                                                                                                                                     | 
 
-Consider an annual plan or Enterprise plan if more than three concurrent builds are required or if you would like unlimited build minutes on premium macOS, Linux, and Windows instances. For more information contact us [here](https://codemagic.io/contact/).
+Consider an annual plan or Enterprise plan if more than three concurrent builds are required or if you would like unlimited build minutes on Intel macOS, Linux, and Windows instances. For more information contact us [here](https://codemagic.io/contact/).
 
 ## Monthly Plan with 4 or more concurrencies
 
@@ -91,7 +91,7 @@ If you need 4 or more concurrencies, paid on a monthly basis, a fixed price **mo
 
 The Codemagic annual plan gives you a fixed price plan with the following benefits:
 
-* 3 concurrencies (premium macOS, Mac mini M1, Linux, and Windows instances)
+* 3 concurrencies (Intel macOS, Mac mini M1, Linux, and Windows instances)
 * Unlimited build minutes
 * Unlimited team seats
 * In-app chat support
@@ -142,7 +142,7 @@ It's possible to resell the Codemagic Enterprise plan. Contact us [here](https:/
 
 If you need specific software and tools available on a builder machine we can provide dedicated macOS host machines which give you 2 VMs. 
 
-Dedicated macOS M1 standard and macOS premium hosts are available for $449/month, paid annually with **20% discount** comes to **$4,310/year**. 
+Dedicated macOS M1 standard and macOS Intel hosts are available for $449/month, paid annually with **20% discount** comes to **$4,310/year**. 
 
 Annual dedicated host plans can be paid for with credit card and invoicing with bank transfer is available.
 

--- a/content/knowledge-codemagic/machine-type.md
+++ b/content/knowledge-codemagic/machine-type.md
@@ -14,7 +14,7 @@ In `codemagic.yaml`, the build machine type can be specified with [Instance type
 
 For Flutter projects configured via the Flutter workflow editor, the build machine type can be selected in **App settings > Workflow settings > Machine**.
 
-## macOS Standard and macOS Premium
+## macOS M1 and Intel
 
 Codemagic offers two types of macOS machines for running builds:
 

--- a/content/knowledge-codemagic/machine-type.md
+++ b/content/knowledge-codemagic/machine-type.md
@@ -19,7 +19,7 @@ For Flutter projects configured via the Flutter workflow editor, the build machi
 Codemagic offers two types of macOS machines for running builds:
 
 * Mac minis with Apple M1 chip (macOS M1 Standard VM, default)
-* Mac Pros (macOS premium VM)
+* Mac Pros with Intel chip (macOS Intel VM)
 
 Check the specific macOS build machine image for machine [specifications](../specs/versions-macos).
 

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -168,7 +168,7 @@ The main sections in each workflow are described below.
 | **Instance Type** | **Build Machine** |
 | ------------- | -----------------  |
 | `mac_mini_m1`    | macOS M1 standard VM (default) |
-| `mac_pro`     | macOS premium VM            |
+| `mac_pro`     | macOS Intel VM            |
 | `linux`       | Linux standard VM           |
 | `linux_x2`    | Linux premium VM            |
 | `windows_x2`  | Windows premium VM          |


### PR DESCRIPTION
Reflect the change in the UI whereby macOS Premium VM was renamed to macOS Intel VM.