### PR TITLE
add new page for teams API

### DIFF
--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -88,7 +88,7 @@ Change the role of your team members. The available roles are `owner` and `devel
 
 #### Example
 
-How to upgrade a current member of your team, to team owner:
+How to upgrade a current member of your team to team owner:
 
 {{< highlight bash "style=paraiso-dark">}}
 curl -H "Content-Type: application/json" \

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -20,10 +20,10 @@ Invite a new team member to your team.
 #### Parameters
 
 
-| **Name** | **Type** | **Description**                                            |
-|----------| -------- |------------------------------------------------------------|
-| `email`  | `string` | **Required.** SSH or HTTPS URL for cloning the repository. |
-| `role`   | `string` | **Required.** Could be `owner` or `developer`              |
+| **Name** | **Type** | **Description**                               |
+|----------| -------- |-----------------------------------------------|
+| `email`  | `string` | **Required.** User email                    |
+| `role`   | `string` | **Required.** Could be `owner` or `developer` |
 
 #### Example
 
@@ -111,7 +111,6 @@ How to upgrade a current member of your team to team owner:
 curl -H "Content-Type: application/json" \
      -H "x-auth-token: <API Token>" \
      -d '{
-        "email": "your_user@domain.com",
         "role": "owner"
      }' \
      -X PUT https://api.codemagic.io/<team_id>/collaborator/<user_id>

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -1,0 +1,162 @@
+---
+title: Teams API
+description: API for managing teams members
+weight: 5
+---
+
+API endpoints for managing teams. To use this API you must be a **team owner**.
+
+>Read more about [managing teams](../getting-started/teams/) 
+
+
+## Invite a new team member
+Invite a new team member to your team.
+
+`POST /:team_id/invitation`
+
+#### Parameters
+
+
+| **Name** | **Type** | **Description**                                            |
+|----------| -------- |------------------------------------------------------------|
+| `email`  | `string` | **Required.** SSH or HTTPS URL for cloning the repository. |
+| `role`   | `string` | **Required.** Could be `owner` or `developer`              |
+
+#### Example
+
+{{< highlight bash "style=paraiso-dark">}}
+curl -H "Content-Type: application/json" \
+     -H "x-auth-token: <API Token>" \
+     -d '{
+        "email": "your_user@domain.com",
+        "role": "developer"
+     }' \
+     -X POST https://api.codemagic.io/<team_id>/invitation
+{{< /highlight >}}
+
+
+#### Response
+
+A full team object is returned. You can see that your invitation is created
+in `invitations` section: 
+
+{{< highlight json "style=paraiso-dark">}}
+{
+  "team":{
+    "_id":"<team_id>",
+    "applicationIds":[...],
+    "billing":{...},
+    "buildTimes": {...},
+    "collaborators":[...],
+    "invitations": [
+        {
+            "invitedFrom":"email",
+            "isPendingRemoved":false,
+            "role":"developer",
+            "addedBy":"<user_id>",
+            "updatedAt": "<update_date>",
+            "createdAt": "<create_date>",
+            "email":"your_user@domain.com",
+            "permissions": [...],
+            "inviteCode":"<invite_code>"}
+        ],
+        ...
+        ...
+    }
+}
+{{< /highlight >}}
+
+
+## Change a team member role
+
+Change the role of your team members (owner or developer).
+
+`PUT /:team_id/collaborator/:user_id`
+
+#### Parameters
+
+
+| **Name** | **Type** | **Description**                                            |
+|----------| -------- |------------------------------------------------------------|
+| `role`   | `string` | **Required.** Could be `owner` or `developer`              |
+
+
+#### Example
+
+How to upgrade a current member of your team, to team owner:
+
+{{< highlight bash "style=paraiso-dark">}}
+curl -H "Content-Type: application/json" \
+     -H "x-auth-token: <API Token>" \
+     -d '{
+        "email": "your_user@domain.com",
+        "role": "owner"
+     }' \
+     -X PUT https://api.codemagic.io/<team_id>/collaborator/<user_id>
+{{< /highlight >}}
+
+
+#### Response
+
+A collaborator objects is returned. You can see that the role is changed:
+
+{{< highlight json "style=paraiso-dark">}}
+
+{
+    "collaborator":
+        {
+            "updatedAt":"<date>",
+            "updatedBy":"<your_user_id>",
+            "createdAt":"<date>",
+            "permissions":
+                [
+                    "apps_delete",
+                    "apps_edit",
+                    ...
+                ],
+            "isActiveRemoved":false,
+            "isExpiring":false,
+            "role":"owner",
+            "user":{<user_info>},
+            "addedBy":"<user_id>",
+            "activatedAt":"<date>"
+        }
+}
+
+{{< /highlight >}}
+
+
+
+## Delete a team
+
+
+`DELETE /:team_id/collaborator/:user_id`
+
+#### Example
+
+{{< highlight bash "style=paraiso-dark">}}
+curl -H "Content-Type: application/json" \
+     -H "x-auth-token: <API Token>" \
+     -X DELETE https://api.codemagic.io/<team_id>/collaborator/<user_id>
+{{< /highlight >}}
+
+
+#### Response
+
+A full team object is returned. You can see that your team member  is removed
+from `collaborators` section: 
+
+{{< highlight json "style=paraiso-dark">}}
+{
+  "team":{
+    "_id":"<team_id>",
+    "applicationIds":[...],
+    "billing":{...},
+    "buildTimes": {...},
+    "collaborators":[...],  // <--- your team member is removed
+    "invitations": [...],
+        ...
+        ...
+    }
+}
+{{< /highlight >}}

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -69,7 +69,8 @@ in `invitations` section:
 
 ## Change a team member role
 
-Change the role of your team members (owner or developer).
+
+Change the role of your team members. The available roles are `owner` and `developer` (corresponds to "member" in the UI).
 
 `PUT /:team_id/collaborator/:user_id`
 
@@ -127,7 +128,7 @@ A collaborator objects is returned. You can see that the role is changed:
 
 
 
-## Delete a team
+## Delete a team member
 
 
 `DELETE /:team_id/collaborator/:user_id`

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -40,8 +40,10 @@ curl -H "Content-Type: application/json" \
 
 #### Response
 
-A full team object is returned. You can see that your invitation is created
-in the `invitations` section: 
+A full team object is returned. You can see that your invitation has been created
+in the `invitations` section.
+Also, you can see your current active team members in the `collaborators` section,
+ where you can locate their `user_ids`.
 
 
 {{< highlight json "style=paraiso-dark">}}
@@ -51,18 +53,33 @@ in the `invitations` section:
     "applicationIds":[...],
     "billing":{...},
     "buildTimes": {...},
-    "collaborators":[...],
-    "invitations": [
+    "collaborators":[                       // <--- current team members
         {
-            "invitedFrom":"email",
-            "isPendingRemoved":false,
-            "role":"developer",
-            "addedBy":"<user_id>",
+            "createdAt": "<date>",
+            "addedBy": "<creator_user_id>",
+            "activatedAt":"<date>",
+            "updatedAt":"<date>",
+            "user":
+                {
+                    "id": <user_id>,        // <--- <user_id> of your team member
+                    "name": <user_name>,
+                    "email": <user_email>
+                },
+        },
+        ...
+    ],
+    "invitations": [                        // <--- you can see your invitation here
+
+        {
+            "invitedFrom": "email",
+            "isPendingRemoved": false,
+            "role": "developer",
+            "addedBy": "<user_id>",
             "updatedAt": "<update_date>",
             "createdAt": "<create_date>",
-            "email":"your_user@domain.com",
+            "email": "your_user@domain.com",
             "permissions": [...],
-            "inviteCode":"<invite_code>"}
+            "inviteCode": "<invite_code>"}
         ],
         ...
         ...
@@ -146,26 +163,3 @@ curl -H "Content-Type: application/json" \
      -X DELETE https://api.codemagic.io/<team_id>/collaborator/<user_id>
 {{< /highlight >}}
 
-
-#### Response
-
-A full team object is returned. You can see that your team member has been removed
-
-from the `collaborators` section: 
-
-
-{{< highlight json "style=paraiso-dark">}}
-{
-  "team":{
-    "_id":"<team_id>",
-    "applicationIds":[...],
-    "billing":{...},
-    "buildTimes": {...},
-    "collaborators":[...],  // <--- your team member has been removed
-
-    "invitations": [...],
-        ...
-        ...
-    }
-}
-{{< /highlight >}}

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -40,10 +40,7 @@ curl -H "Content-Type: application/json" \
 
 #### Response
 
-A full team object is returned. You can see that your invitation has been created
-in the `invitations` section.
-Also, you can see your current active team members in the `collaborators` section,
- where you can locate their `user_ids`.
+A full team object is returned.
 
 
 

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -42,7 +42,7 @@ curl -H "Content-Type: application/json" \
 A full team object is returned.
 
 ## Delete a team member
-
+Remove a team member from the team.
 `DELETE /:team_id/collaborator/:user_id`
 
 #### Example

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -88,67 +88,6 @@ Also, you can see your current active team members in the `collaborators` sectio
 {{< /highlight >}}
 
 
-## Change a team member role
-
-
-Change the role of your team members. The available roles are `owner` and `developer` (corresponds to "member" in the UI).
-
-`PUT /:team_id/collaborator/:user_id`
-
-#### Parameters
-
-
-| **Name** | **Type** | **Description**                                            |
-|----------| -------- |------------------------------------------------------------|
-| `role`   | `string` | **Required.** Could be `owner` or `developer`              |
-
-
-#### Example
-
-How to upgrade a current member of your team to team owner:
-
-{{< highlight bash "style=paraiso-dark">}}
-curl -H "Content-Type: application/json" \
-     -H "x-auth-token: <API Token>" \
-     -d '{
-        "role": "owner"
-     }' \
-     -X PUT https://api.codemagic.io/<team_id>/collaborator/<user_id>
-{{< /highlight >}}
-
-
-#### Response
-
-A collaborator object is returned. You can see that the role has changed:
-
-
-{{< highlight json "style=paraiso-dark">}}
-
-{
-    "collaborator":
-        {
-            "updatedAt":"<date>",
-            "updatedBy":"<your_user_id>",
-            "createdAt":"<date>",
-            "permissions":
-                [
-                    "apps_delete",
-                    "apps_edit",
-                    ...
-                ],
-            "isActiveRemoved":false,
-            "isExpiring":false,
-            "role":"owner",
-            "user":{<user_info>},
-            "addedBy":"<user_id>",
-            "activatedAt":"<date>"
-        }
-}
-
-{{< /highlight >}}
-
-
-
 ## Delete a team member
 
 

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -7,10 +7,7 @@ weight: 5
 
 This document describes the API endpoints for managing teams. To use this API, you must be a **team owner**.
 
-
 >Read more about the [Teams](../getting-started/teams/) feature, the available user roles and permissions.
-
-
 
 ## Invite a new team member
 Invite a new team member to your team.
@@ -19,11 +16,14 @@ Invite a new team member to your team.
 
 #### Parameters
 
-
 | **Name** | **Type** | **Description**                               |
 |----------| -------- |-----------------------------------------------|
 | `email`  | `string` | **Required.** User email                    |
 | `role`   | `string` | **Required.** Could be `owner` or `developer` |
+
+<br />
+
+>`developer` role corresponds to the "Member" role in Codemagic UI.
 
 #### Example
 
@@ -37,16 +37,11 @@ curl -H "Content-Type: application/json" \
      -X POST https://api.codemagic.io/<team_id>/invitation
 {{< /highlight >}}
 
-
 #### Response
 
 A full team object is returned.
 
-
-
-
 ## Delete a team member
-
 
 `DELETE /:team_id/collaborator/:user_id`
 

--- a/content/rest-api/teams.md
+++ b/content/rest-api/teams.md
@@ -46,46 +46,6 @@ Also, you can see your current active team members in the `collaborators` sectio
  where you can locate their `user_ids`.
 
 
-{{< highlight json "style=paraiso-dark">}}
-{
-  "team":{
-    "_id":"<team_id>",
-    "applicationIds":[...],
-    "billing":{...},
-    "buildTimes": {...},
-    "collaborators":[                       // <--- current team members
-        {
-            "createdAt": "<date>",
-            "addedBy": "<creator_user_id>",
-            "activatedAt":"<date>",
-            "updatedAt":"<date>",
-            "user":
-                {
-                    "id": <user_id>,        // <--- <user_id> of your team member
-                    "name": <user_name>,
-                    "email": <user_email>
-                },
-        },
-        ...
-    ],
-    "invitations": [                        // <--- you can see your invitation here
-
-        {
-            "invitedFrom": "email",
-            "isPendingRemoved": false,
-            "role": "developer",
-            "addedBy": "<user_id>",
-            "updatedAt": "<update_date>",
-            "createdAt": "<create_date>",
-            "email": "your_user@domain.com",
-            "permissions": [...],
-            "inviteCode": "<invite_code>"}
-        ],
-        ...
-        ...
-    }
-}
-{{< /highlight >}}
 
 
 ## Delete a team member


### PR DESCRIPTION
Task: https://trello.com/c/Q9FqpxCy/2037-documentation-for-user-management


New page for teams API added to documentation with the endpoints suggested.

Probably for our users it is also necessary to document `GET /:team_id` , to have direct access to "invitation status" and "user_ids" of the team.
