### PR TITLE
add 2021.3.23f1 and 2022.2.16f1 to unity versions

### DIFF
--- a/content/knowledge-others/install-unity-version.md
+++ b/content/knowledge-others/install-unity-version.md
@@ -24,6 +24,9 @@ This will automatically install the specified Unity version to the build machine
 
 #### The supported Unity versions on Mac machines are the following:
 {{< tabpane >}}
+{{% tab header="2022.X" %}}
+- `2022.2.16f1`
+{{< /tab >}}
 {{% tab header="2021.X" %}}
 - `2021.3.4f1`
 - `2021.3.6f1`
@@ -34,6 +37,7 @@ This will automatically install the specified Unity version to the build machine
 - `2021.3.12f1`
 - `2021.3.13f1`
 - `2021.3.15f1`
+- `2021.3.23f1`
 {{< /tab >}}
 {{% tab header="2020.X" %}}
 - `2020.3.15f2`


### PR DESCRIPTION
we now have 2021.3.23f1 and 2022.2.16f1 archives available for x86_64

## QA
✅ tested both versions on mac Pro
<img width="682" alt="image" src="https://user-images.githubusercontent.com/10799770/235221527-cd50ea64-480c-47a8-86b5-1c4dcd964483.png">
