### PR TITLE
Add example on how to set the `instance_type` via the API

### DIFF
--- a/content/rest-api/builds.md
+++ b/content/rest-api/builds.md
@@ -60,7 +60,8 @@ APIs for managing builds are currently available for developers to preview. Duri
       "xcode": "11.4.1",
       "flutter": "v1.12.13+hotfix.9"
     }
-  }
+  },
+  "instanceType": "mac_mini_m1"
 }
 {{< /highlight >}}
 


### PR DESCRIPTION
I wondered how to change the `instance_type` via the API. Unfortunately, I couldn't find any information about this in the documentation. Therefore, I tried `instance_type` first. This hasn't worked. Then I tried `instanceType`. This worked :)

Therefore, I thought, it would be maybe helpful to mention this in the documentation ["Pass custom build parameters" section](https://docs.codemagic.io/rest-api/builds/#pass-custom-build-parameters).