### PR TITLE
Update that XCode 14.3 is the default option for Mac M1

### DIFF
--- a/content/partials/specs/versions-macos-m1-xcode-14-2.md
+++ b/content/partials/specs/versions-macos-m1-xcode-14-2.md
@@ -69,8 +69,8 @@ Android emulators are not available on M1 machines. Please use a Mac Pro or a Li
 
 ## Xcode versions
 
-- 14.3 (14E222b) `/Applications/Xcode-14.3.app`
-- 14.2 (14C18) `/Applications/Xcode-14.2.app`, also selected when specifying `latest` or `edge` in Xcode version settings
+- 14.3 (14E222b) `/Applications/Xcode-14.3.app`, also selected when specifying `latest` or `edge` in Xcode version settings
+- 14.2 (14C18) `/Applications/Xcode-14.2.app`
 
 ### Runtimes
 


### PR DESCRIPTION
## Summary

Since April 19, XCode 14.3 is the default option for Mac M1. This PR updates this information in the docs because it still said that XCode 14.2 is the default option.

## Description

From the [GitHub discussion](https://github.com/orgs/codemagic-ci-cd/discussions/1545):

> As you may already know, Apple released Xcode 14.3 on March 31. This version requires a Mac running macOS Ventura 13.0 or later, which may cause breaking changes when switching from a macOS Monterey 12.x build machine. Please ensure your Xcode projects are updated locally before updating CI/CD configuration on Codemagic.
> 
> Additionally, Xcode 14.3 is only available on Mac mini M1 machines and is not available on Intel-based Mac Pro or older machines. The highest available Xcode version on Intel-based machines is Xcode 14.2. Please review your build configuration to avoid build failures.
> 
> **On April 19, we will change the default behavior for builds configured to use Xcode `latest` or` edge` version and run them using the Xcode 14.3 Release version.** If you already build with Xcode 14.3, no changes are required from your side.
> 
> See the [build machine specs](https://docs.codemagic.io/specs/versions-macos/) for information about the preinstalled software and available runtimes.
> 
> If you run into any unexpected behavior or any other problems when upgrading your workflow to use Mac mini M1 build machine, please let us know in this thread or by reaching out to support via the in-app Chat widget.

