### PR TITLE
Update email-and-slack-notifications.md

### DIFF
--- a/content/flutter-notification/email-and-slack-notifications.md
+++ b/content/flutter-notification/email-and-slack-notifications.md
@@ -41,4 +41,6 @@ To receive a notification when a build starts, check the checkbox **Notify when 
 
 When you set up email or Slack publishing, Codemagic publishes the following artifacts:
 
-- `app`, `ipa`, `apk`, the archive with Flutter web build directory, Linux application bundle files, Windows MSIX packages
+- `app`, `ipa`, `apk`, the archive with Flutter web build directory, Linux application bundle files, Windows MSIX packages, and .exe files.
+
+** NOTE: We only send emails on successful builds when there are above mentioned artifact types **

--- a/content/yaml-notification/email.md
+++ b/content/yaml-notification/email.md
@@ -33,3 +33,4 @@ When you set up email publishing, Codemagic publishes the following artifacts:
 - the archive with Flutter web build directory
 - Linux application bundle files
 - Windows MSIX packages
+- .exe


### PR DESCRIPTION
Added .exe support for Artifacts and a note that emails will only be sent on succesful builds with the artifacts.