### PR TITLE
Dart Code Metrics deprecation note

### DIFF
--- a/content/flutter-testing/static-code-analysis.md
+++ b/content/flutter-testing/static-code-analysis.md
@@ -16,7 +16,7 @@ When enabled, `flutter analyze` will be run with each build. You can see the res
 ### Dart Code Metrics
 
 {{<notebox>}}
-**Important!** The Dart Code Metrics integration in Flutter workflow editor will be unavailable from July 16, 2023 onwards as the [dart_code_metrics](https://pub.dev/packages/dart_code_metrics) plugin will be deprecated. Please read the plugin maintainers' [official announcement](https://metabase.flutterci.com/public/dashboard/31550fb9-97a7-400e-87c7-361a38cfe0d8) for more information.
+**Important!** The Dart Code Metrics integration in Flutter workflow editor will be unavailable from July 16, 2023 onwards as the [dart_code_metrics](https://pub.dev/packages/dart_code_metrics) plugin will be deprecated. Please read the plugin maintainers' [official announcement](https://dcm.dev/blog/2023/06/06/announcing-dcm-free-version-sunset/) for more information.
 {{</notebox>}}
 
 Codemagic is integrated with [Dart Code Metrics](https://pub.dev/packages/dart_code_metrics), helping to improve code quality. With Dart Code Metrics it is possible to report code metrics, define additional rules for your dart analyzer and check for anti-patterns.

--- a/content/flutter-testing/static-code-analysis.md
+++ b/content/flutter-testing/static-code-analysis.md
@@ -16,7 +16,7 @@ When enabled, `flutter analyze` will be run with each build. You can see the res
 ### Dart Code Metrics
 
 {{<notebox>}}
-**Note:** To run Dart Code Metrics with Codemagic, Flutter version 1.27.0-1.0.pre or higher is required.
+**Important!** The Dart Code Metrics integration in Flutter workflow editor will be unavailable from July 16, 2023 onwards as the [dart_code_metrics](https://pub.dev/packages/dart_code_metrics) plugin will be deprecated. Please read the plugin maintainers' [official announcement](https://metabase.flutterci.com/public/dashboard/31550fb9-97a7-400e-87c7-361a38cfe0d8) for more information.
 {{</notebox>}}
 
 Codemagic is integrated with [Dart Code Metrics](https://pub.dev/packages/dart_code_metrics), helping to improve code quality. With Dart Code Metrics it is possible to report code metrics, define additional rules for your dart analyzer and check for anti-patterns.

--- a/content/yaml-testing/dart-code-metrics.md
+++ b/content/yaml-testing/dart-code-metrics.md
@@ -5,7 +5,7 @@ weight: 3
 ---
 </p>
 {{<notebox>}}
-**Note:** For the following instructions to work with Codemagic, Dart version 2.12.0 (Flutter 1.27.0-1.0.pre) or higher is required.
+**Important!** The Dart Code Metrics integration will be unavailable from July 16, 2023 onwards as the [dart_code_metrics](https://pub.dev/packages/dart_code_metrics) plugin will be deprecated. Please read the plugin maintainers' [official announcement](https://metabase.flutterci.com/public/dashboard/31550fb9-97a7-400e-87c7-361a38cfe0d8) for more information.
 {{</notebox>}}
 
 Codemagic is integrated with [Dart Code Metrics](https://pub.dev/packages/dart_code_metrics), helping to improve code quality for projects utilizing dart files. With Dart Code Metrics, it is possible to report code metrics, define additional rules for your dart analyzer, and check for anti-patterns.

--- a/content/yaml-testing/dart-code-metrics.md
+++ b/content/yaml-testing/dart-code-metrics.md
@@ -5,7 +5,7 @@ weight: 3
 ---
 </p>
 {{<notebox>}}
-**Important!** The Dart Code Metrics integration will be unavailable from July 16, 2023 onwards as the [dart_code_metrics](https://pub.dev/packages/dart_code_metrics) plugin will be deprecated. Please read the plugin maintainers' [official announcement](https://metabase.flutterci.com/public/dashboard/31550fb9-97a7-400e-87c7-361a38cfe0d8) for more information.
+**Important!** The Dart Code Metrics integration will be unavailable from July 16, 2023 onwards as the [dart_code_metrics](https://pub.dev/packages/dart_code_metrics) plugin will be deprecated. Please read the plugin maintainers' [official announcement](https://dcm.dev/blog/2023/06/06/announcing-dcm-free-version-sunset/) for more information.
 {{</notebox>}}
 
 Codemagic is integrated with [Dart Code Metrics](https://pub.dev/packages/dart_code_metrics), helping to improve code quality for projects utilizing dart files. With Dart Code Metrics, it is possible to report code metrics, define additional rules for your dart analyzer, and check for anti-patterns.


### PR DESCRIPTION
Update workflow editor and yaml docs with the note about the upcoming deprecation of the dart_code_metrics plugin.