### PR TITLE
A required agreement is missing or has expired

### DIFF
--- a/content/troubleshooting/common-ios-issues.md
+++ b/content/troubleshooting/common-ios-issues.md
@@ -203,7 +203,7 @@ In XCode 13 `CODE_SIGNING_ALLOWED` was set to `NO` by default for resource bundl
 ### A required agreement is missing or has expired
 
 ###### Description
-Suddenly, the builds started failing with the following message, even though we haven't made any updates to the code:
+Builds are failing with the following message:
 
     A required agreement is missing or has expired. - This request requires an in-effect agreement that has not been signed or has expired.
 

--- a/content/troubleshooting/common-ios-issues.md
+++ b/content/troubleshooting/common-ios-issues.md
@@ -199,3 +199,16 @@ end
 {{< /highlight >}}
 
 In XCode 13 `CODE_SIGNING_ALLOWED` was set to `NO` by default for resource bundles. While in Xcode 14 they changed this to default to `YES`, which might be causing the problems.
+
+### A required agreement is missing or has expired
+
+###### Description
+Suddenly, the builds started failing with the following message, even though we haven't made any updates to the code:
+
+    A required agreement is missing or has expired. - This request requires an in-effect agreement that has not been signed or has expired.
+
+###### Cause
+Apple has updated Apple Developer Program License Agreement and it needs to be reviewed
+
+###### Solution
+In order to update your existing apps and submit new apps to the App Store, the Account Holder must review and accept the updated agreement by signing in to their [account](https://appstoreconnect.apple.com/agreements/#/) on the Apple Developer website.


### PR DESCRIPTION
Updated common iOS issue page about the "A required agreement is missing or has expired" error