### PR TITLE
reinstate Flutter iOS auto codesigning video embed

### DIFF
--- a/content/flutter-code-signing/ios-code-signing.md
+++ b/content/flutter-code-signing/ios-code-signing.md
@@ -44,6 +44,8 @@ In short, the purpose of the different provisioning profiles is the following:
 
 ## Automatic code signing
 
+{{< youtube aBDx6BKFXIA >}}
+
 Codemagic makes automatic code signing possible by connecting to [App Store Connect via its API](https://developer.apple.com/app-store-connect/api/) for creating and managing your code signing certificates and provisioning profiles. It is possible to set up several code signing identities and use different code signing settings per workflow.
 
 The following sections describe how to set up automatic code signing for builds configured in the UI. If you're building with `codemagic.yaml`, please refer [here](../code-signing-yaml/signing-ios).


### PR DESCRIPTION
For some reason this video embed was lost at some point, so re-instating it, as its still relevant to the topic.