### PR TITLE
add utm tags to codelab links

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -11,7 +11,7 @@ How to get started with Codemagic
 - [Signup](../getting-started/signup/)
 - [Adding apps to Codemagic](../getting-started/adding-apps/)
 - [Onboarding assistance](https://codemagic.io/onboarding-assistance/)
-- [Publish your first Flutter app to the App Store](https://labs.codemagic.io/your-first-flutter-app-to-appstore)
+- [Publish your first Flutter app to the App Store](https://labs.codemagic.io/your-first-flutter-app-to-appstore?utm_source=codemagic&utm_medium=docs&utm_campaign=landingpage&utm_id=codelab)
 
 
 {{</links-group>}} 

--- a/content/flutter-configuration/flutter-projects.md
+++ b/content/flutter-configuration/flutter-projects.md
@@ -52,7 +52,7 @@ When you enroll an app into app signing by Google Play, Google will manage your 
 ## Building iOS apps
 
 {{<notebox>}}
-**Tip:** If you are new to building Flutter apps for iOS, you can start by working through the beginner friendly, [step by step tutorial we have that shows you how to build your first Flutter app for iOS](https://labs.codemagic.io/your-first-flutter-app-to-appstore). 
+**Tip:** If you are new to building Flutter apps for iOS, you can start by working through the beginner friendly, [step by step tutorial we have that shows you how to build your first Flutter app for iOS](https://labs.codemagic.io/your-first-flutter-app-to-appstore?utm_source=codemagic&utm_medium=docs&utm_campaign=flutter-projects&utm_id=codelab). 
 {{</notebox>}}
 
 In your app settings, select **iOS** under **Build for platforms** and an available build machine type.


### PR DESCRIPTION
This adds utm tags that were missed out in previous addition of the links to the codelab.