### PR TITLE
separated instructions for wfe and yaml for uploading dSYM file to Firebase

### DIFF
--- a/content/knowledge-firebase/firebase-crashlytics-dsym-uploading.md
+++ b/content/knowledge-firebase/firebase-crashlytics-dsym-uploading.md
@@ -1,15 +1,17 @@
 ---
-description: How to upload dSYM artifacts to Firebase Crashlytics
 title: Firebase Crashlytics dSYM uploading
+description: Enhancing Crash Log Debugging with dSYM files
 weight: 13
 aliases:
   - /custom-scripts/firebase-crashlytics-dsym-uploading
   - knowledge-base/firebase-crashlytics-dsym-uploading
 ---
-
-**dSYM** files store the debug symbols for your app. They contain mapping information to decode a stack-trace into a readable format. The purpose of **dSYM** is to replace symbols in the crash logs with the specific methods so it will be readable and helpful for debugging the crash. 
+**dSYM** files store the debug symbols for your app. They contain mapping information to decode a stack-trace into a readable format. 
+The purpose of **dSYM** is to replace symbols in the crash logs with the specific methods so it will be readable and helpful for debugging the crash. 
 
 A sample project for uploading **dSYM** files to Firebase Crashlytics can be found in our [Sample projects repository](https://github.com/codemagic-ci-cd/codemagic-sample-projects/tree/main/integrations/firebase_crashlytics_demo_project).
+
+### How to upload dSYM artifacts to Firebase Crashlytics using codemagic.yaml
 
 In order to generate debug symbols, Firebase Crashlytics must be installed using the following script in your `codemagic.yaml`:
 
@@ -38,7 +40,7 @@ As soon as your build finishes successfully, debug symbols are generated. Howeve
     - $HOME/Library/Developer/Xcode/DerivedData/**/Build/**/*.dSYM
 {{< /highlight >}}
 
-In order to upload the dSYM files to Firebase Crashlytics, add the following script to your `codemagic.yaml` configuration file or to your post-publish script in the Flutter workflow editor: 
+In order to upload the dSYM files to Firebase Crashlytics, add the following script to your `codemagic.yaml` configuration file:
 
 {{< highlight yaml "style=paraiso-dark">}}
 publishing:
@@ -102,3 +104,20 @@ publishing:
         fi
 {{< /highlight >}}
 
+### How to upload dSYM artifacts to Firebase Crashlytics using Workflow Editor
+
+In order to upload the dSYM files to Firebase Crashlytics, add the following script to  your **post-publish** script in the Flutter workflow editor:
+
+{{< highlight yaml "style=paraiso-dark">}}
+  echo "Find build artifacts"
+  dsymPath=$(find $CM_BUILD_DIR/build/ios/archive/Runner.xcarchive -name "*.dSYM" | head -1)
+  if [[ -z ${dsymPath} ]]
+  then
+    echo "No debug symbols were found, skip publishing to Firebase Crashlytics"
+  else
+    echo "Publishing debug symbols from $dsymPath to Firebase Crashlytics"
+    ls -d -- ios/Pods/*
+    $CM_BUILD_DIR/ios/Pods/FirebaseCrashlytics/upload-symbols \
+      -gsp ios/Runner/GoogleService-Info.plist -p ios $dsymPath
+  fi
+{{< /highlight >}}


### PR DESCRIPTION
added a separate, much more visible step for uploading dSYM file to Firebase, since we have a lot of queries on how to do it with wfe