### PR TITLE
add pre-rendered yaml cheatsheet html page

### DIFF
--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -15,6 +15,7 @@ popular: 1
 
 
 {{< youtube er7hRWhW0B0 >}}
+
 ## Building with YAML
 
 In order to use `codemagic.yaml` for build configuration on Codemagic, it has to be committed to your repository. The name of the file must be `codemagic.yaml` and it must be located in the root directory of the repository.
@@ -22,6 +23,13 @@ In order to use `codemagic.yaml` for build configuration on Codemagic, it has to
 When detected in the repository, `codemagic.yaml` is automatically used for configuring builds triggered in response to the events defined in the file, provided that a [webhook](../building/webhooks) is set up. 
 
 Builds can also be started manually by clicking **Start new build** in Codemagic and selecting the branch and workflow to build in the **Specify build configuration** popup.
+
+
+{{<notebox>}}
+
+Check out the [**cheatsheet**](/codemagic-yaml-cheatsheet.html) we have created to help you when using Codemagic YAML.
+
+{{</notebox>}}
 
 ## Syntax
 

--- a/static/codemagic-yaml-cheatsheet.html
+++ b/static/codemagic-yaml-cheatsheet.html
@@ -1,0 +1,3207 @@
+<!doctype html>
+<html class='NoJs' lang='en'><head>
+
+<meta charset='utf-8'>
+<meta content='width=device-width, initial-scale=1.0' name='viewport'>
+<link href='./assets/favicon.png' rel='shortcut icon'>
+<meta content='/codemagic-yaml.html' name='app:pageurl'>
+
+  <title>Codemagic.yaml cheatsheet</title>
+  <meta content='Codemagic.yaml cheatsheet' property='og:title'>
+  <meta content='Codemagic.yaml cheatsheet' property='twitter:title'>
+  <meta content='article' property='og:type'>
+
+  <meta content='https://assets.devhints.io/previews/codemagic-yaml.jpg?t=20230630061434' property='og:image'>
+  <meta content='https://assets.devhints.io/previews/codemagic-yaml.jpg?t=20230630061434' property='twitter:image'>
+  <meta content='900' property='og:image:width'>
+  <meta content='471' property='og:image:height'>
+
+  <meta content='Devhints.io cheatsheets' property='og:site_name'>
+
+  <meta content='CLI' property='article:section'>
+
+  <meta content='Featured' property='article:tag'>
+
+  <meta property='page:depth' content='1'>
+
+
+<script>(function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement)</script>
+<script>(function(H){H.className=H.className.replace(/\bNoJs\b/,'WithJs')})(document.documentElement)</script>
+
+<script>(function(d,s){if(window.Promise&&[].includes&&Object.assign&&window.Map)return;var js,sc=d.getElementsByTagName(s)[0];js=d.createElement(s);js.src='https://cdn.polyfill.io/v2/polyfill.min.js';sc.parentNode.insertBefore(js, sc);}(document,'script'))</script>
+
+
+<!-- critical css -->
+<style id='critical-css'>/* Document
+ * ========================================================================== */
+
+/**
+ * Add border box sizing in all browsers (opinionated).
+ */
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+
+/**
+ * 1. Add text decoration inheritance in all browsers (opinionated).
+ * 2. Add vertical alignment inheritance in all browsers (opinionated).
+ */
+
+::before,
+::after {
+  text-decoration: inherit; /* 1 */
+  vertical-align: inherit; /* 2 */
+}
+
+/**
+ * 1. Use the default cursor in all browsers (opinionated).
+ * 2. Change the line height in all browsers (opinionated).
+ * 3. Use a 4-space tab width in all browsers (opinionated).
+ * 4. Remove the grey highlight on links in iOS (opinionated).
+ * 5. Prevent adjustments of font size after orientation changes in
+ *    IE on Windows Phone and in iOS.
+ * 6. Breaks words to prevent overflow in all browsers (opinionated).
+ */
+
+html {
+  cursor: default; /* 1 */
+  line-height: 1.5; /* 2 */
+  -moz-tab-size: 4; /* 3 */
+  tab-size: 4; /* 3 */
+  -webkit-tap-highlight-color: transparent /* 4 */;
+  -ms-text-size-adjust: 100%; /* 5 */
+  -webkit-text-size-adjust: 100%; /* 5 */
+  word-break: break-word; /* 6 */
+}
+
+/* Sections
+ * ========================================================================== */
+
+/**
+ * Remove the margin in all browsers (opinionated).
+ */
+
+body {
+  margin: 0;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Edge, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+ * ========================================================================== */
+
+/**
+ * Remove the margin on nested lists in Chrome, Edge, IE, and Safari.
+ */
+
+dl dl,
+dl ol,
+dl ul,
+ol dl,
+ul dl {
+  margin: 0;
+}
+
+/**
+ * Remove the margin on nested lists in Edge 18- and IE.
+ */
+
+ol ol,
+ol ul,
+ul ol,
+ul ul {
+  margin: 0;
+}
+
+/**
+ * 1. Add the correct sizing in Firefox.
+ * 2. Show the overflow in Edge 18- and IE.
+ */
+
+hr {
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * Add the correct display in IE.
+ */
+
+main {
+  display: block;
+}
+
+/**
+ * Remove the list style on navigation lists in all browsers (opinionated).
+ */
+
+nav ol,
+nav ul {
+  list-style: none;
+  padding: 0;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+ * ========================================================================== */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Add the correct text decoration in Edge 18-, IE, and Safari.
+ */
+
+abbr[title] {
+  text-decoration: underline;
+  text-decoration: underline dotted;
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/* Embedded content
+ * ========================================================================== */
+
+/*
+ * Change the alignment on media elements in all browsers (opinionated).
+ */
+
+audio,
+canvas,
+iframe,
+img,
+svg,
+video {
+  vertical-align: middle;
+}
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+audio,
+video {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in iOS 4-7.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Remove the border on iframes in all browsers (opinionated).
+ */
+
+iframe {
+  border-style: none;
+}
+
+/**
+ * Remove the border on images within links in IE 10-.
+ */
+
+img {
+  border-style: none;
+}
+
+/**
+ * Change the fill color to match the text color in all browsers (opinionated).
+ */
+
+svg:not([fill]) {
+  fill: currentColor;
+}
+
+/**
+ * Hide the overflow in IE.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Tabular data
+ * ========================================================================== */
+
+/**
+ * Collapse border spacing in all browsers (opinionated).
+ */
+
+table {
+  border-collapse: collapse;
+}
+
+/* Forms
+ * ========================================================================== */
+
+/**
+ * Remove the margin on controls in Safari.
+ */
+
+button,
+input,
+select {
+  margin: 0;
+}
+
+/**
+ * 1. Show the overflow in IE.
+ * 2. Remove the inheritance of text transform in Edge 18-, Firefox, and IE.
+ */
+
+button {
+  overflow: visible; /* 1 */
+  text-transform: none; /* 2 */
+}
+
+/**
+ * Correct the inability to style buttons in iOS and Safari.
+ */
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+ * 1. Change the inconsistent appearance in all browsers (opinionated).
+ * 2. Correct the padding in Firefox.
+ */
+
+fieldset {
+  border: 1px solid #a0a0a0; /* 1 */
+  padding: 0.35em 0.75em 0.625em; /* 2 */
+}
+
+/**
+ * Show the overflow in Edge 18- and IE.
+ */
+
+input {
+  overflow: visible;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge 18- and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ */
+
+legend {
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * 1. Add the correct display in Edge 18- and IE.
+ * 2. Add the correct vertical alignment in Chrome, Edge, and Firefox.
+ */
+
+progress {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Remove the inheritance of text transform in Firefox.
+ */
+
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Remove the margin in Firefox and Safari.
+ * 2. Remove the default vertical scrollbar in IE.
+ * 3. Change the resize direction in all browsers (opinionated).
+ */
+
+textarea {
+  margin: 0; /* 1 */
+  overflow: auto; /* 2 */
+  resize: vertical; /* 3 */
+}
+
+/**
+ * Remove the padding in IE 10-.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  padding: 0;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome, Edge, and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Safari.
+ */
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * Correct the text style of placeholders in Chrome, Edge, and Safari.
+ */
+
+::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+/**
+ * Remove the inner padding in Chrome, Edge, and Safari on macOS.
+ */
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style upload buttons in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/**
+ * Remove the inner border and padding of focus outlines in Firefox.
+ */
+
+::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus outline styles unset by the previous rule in Firefox.
+ */
+
+:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Remove the additional :invalid styles in Firefox.
+ */
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/* Interactive
+ * ========================================================================== */
+
+/*
+ * Add the correct display in Edge 18- and IE.
+ */
+
+details {
+  display: block;
+}
+
+/*
+ * Add the correct styles in Edge 18-, IE, and Safari.
+ */
+
+dialog {
+  background-color: white;
+  border: solid;
+  color: black;
+  display: block;
+  height: -moz-fit-content;
+  height: -webkit-fit-content;
+  height: fit-content;
+  left: 0;
+  margin: auto;
+  padding: 1em;
+  position: absolute;
+  right: 0;
+  width: -moz-fit-content;
+  width: -webkit-fit-content;
+  width: fit-content;
+}
+
+dialog:not([open]) {
+  display: none;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Scripting
+ * ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+canvas {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in IE.
+ */
+
+template {
+  display: none;
+}
+
+/* User interaction
+ * ========================================================================== */
+
+/*
+ * 1. Remove the tapping delay in IE 10.
+ * 2. Remove the tapping delay on clickable elements
+      in all browsers (opinionated).
+ */
+
+a,
+area,
+button,
+input,
+label,
+select,
+summary,
+textarea,
+[tabindex] {
+  -ms-touch-action: manipulation; /* 1 */
+  touch-action: manipulation; /* 2 */
+}
+
+/**
+ * Add the correct display in IE 10-.
+ */
+
+[hidden] {
+  display: none;
+}
+
+/* Accessibility
+ * ========================================================================== */
+
+/**
+ * Change the cursor on busy elements in all browsers (opinionated).
+ */
+
+[aria-busy="true"] {
+  cursor: progress;
+}
+
+/*
+ * Change the cursor on control elements in all browsers (opinionated).
+ */
+
+[aria-controls] {
+  cursor: pointer;
+}
+
+/*
+ * Change the cursor on disabled, not-editable, or otherwise
+ * inoperable elements in all browsers (opinionated).
+ */
+
+[aria-disabled="true"],
+[disabled] {
+  cursor: not-allowed;
+}
+
+/*
+ * Change the display on visually hidden accessible elements
+ * in all browsers (opinionated).
+ */
+
+[aria-hidden="false"][hidden] {
+  display: initial;
+}
+
+[aria-hidden="false"][hidden]:not(:focus) {
+  clip: rect(0, 0, 0, 0);
+  position: absolute;
+}
+/*
+ * Metrics
+ */
+/*
+ * Fonts
+ */
+/*
+ * Base colors
+ */
+/*
+ * Mod scale
+ */
+/*
+ * Base
+ */
+html, body {
+  background: #f1f3f5;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #345;
+  overflow-x: hidden;
+}
+
+body {
+  font-size: 13px;
+  padding: 0;
+  margin: 0;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  body {
+    font-size: calc( 13px + 1 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  body {
+    font-size: calc( 14px + 0 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  body {
+    font-size: 14px;
+  }
+}
+
+/*
+ * Code
+ */
+pre, code {
+  font-family: cousine, "SFMono-Regular", Consolas, Menlo, "Liberation Mono", "Ubuntu Mono", Courier, monospace;
+  letter-spacing: -0.03em;
+}
+
+pre {
+  font-size: 0.96em;
+}
+
+/*
+ * Antialias
+ */
+*:not(pre):not(code) {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/*
+ * Links
+ */
+a {
+  color: #26648e;
+}
+
+a:visited {
+  color: #15234d;
+}
+
+a:hover {
+  color: #3ac1cb;
+}
+
+@media (max-width: 580px) {
+  .hint--bottom::before, .hint--bottom::after {
+    display: none;
+  }
+}
+/*
+/* "Preloader":
+ * This makes the content semi-transparent before the page ad loads.
+ */
+html.WithJs .post-content {
+  opacity: 0;
+}
+
+/*
+ * Defer "loading" until page's onload event fires.
+ * (The page actually already loaded, we just pretend like it hasn't)
+ */
+html.WithJs .pages-list,
+html.WithJs .post-content.-wrapified,
+html.WithJs .intro-content {
+  opacity: 0.98;
+}
+html.WithJs.LoadDone .pages-list,
+html.WithJs.LoadDone .post-content.-wrapified,
+html.WithJs.LoadDone .intro-content {
+  opacity: 1;
+  transition: opacity 100ms linear 100ms;
+}
+
+/*
+ * For links with sources, eg,
+ * [Foo](foo.com) _(foo.com)_
+ */
+.MarkdownBody.MarkdownBody a + em {
+  opacity: 0.5;
+}
+
+.MarkdownBody code {
+  color: #556677;
+  font-size: 0.96em;
+}
+
+.MarkdownBody pre,
+.MarkdownBody code {
+  font-family: cousine, "SFMono-Regular", Consolas, Menlo, "Liberation Mono", "Ubuntu Mono", Courier, monospace;
+}
+
+.MarkdownBody pre.-box-chars {
+  line-height: 1.32;
+}
+
+.MarkdownBody pre.-figlet {
+  line-height: 1;
+  font-size: 11px;
+}
+
+/*
+ * Undo prism theme crap
+ */
+.MarkdownBody pre {
+  box-shadow: none;
+  border-left: 0;
+  overflow: hidden;
+  overflow-x: auto;
+  background: white;
+  font-size: 0.96em;
+  line-height: 1.5;
+}
+.MarkdownBody pre.-wrap {
+  white-space: pre-wrap;
+}
+.MarkdownBody pre > code {
+  color: #111;
+  max-height: auto;
+  padding: 0;
+  background: transparent;
+  overflow: visible;
+  font-size: 1em;
+}
+.MarkdownBody .line-highlight {
+  transform: translate3d(0, 2px, 0);
+  background: linear-gradient(to right, rgba(20, 175, 131, 0.05) 25%, transparent);
+}
+.MarkdownBody .line-highlight[data-end] {
+  margin-top: 0;
+}
+.MarkdownBody .line-highlight::before,
+.MarkdownBody .line-highlight::after {
+  display: none;
+}
+
+.MarkdownBody pre.-setup,
+.MarkdownBody p.-setup,
+.MarkdownBody ul.-setup,
+.MarkdownBody p.-crosslink {
+  background: #f8f9fa;
+}
+
+/*
+ * Syntax kighlight
+ */
+.token.tag, .token.keyword {
+  color: #26648e;
+}
+.token.tag {
+  color: #1d406e;
+}
+.token.value, .token.string, .token.number, .token.attr-value, .token.boolean, .token.regex {
+  color: #14af83;
+}
+.token.function, .token.attr-name {
+  color: #2e90ae;
+}
+.token.punctuation, .token.operator {
+  color: #669;
+}
+.token.comment {
+  color: #569;
+}
+
+/*
+ * MarkdownBody context
+ */
+.MarkdownBody h2 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 24px;
+  margin-top: 64px;
+  position: relative;
+  font-size: 30.0697899531px;
+  line-height: 1.2;
+  font-weight: 200;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  margin-top: 0;
+}
+@media (max-width: 768px) {
+  .MarkdownBody h2 {
+    margin-bottom: 8px;
+    margin-top: 32px;
+  }
+}
+@media (max-width: 480px) {
+  .MarkdownBody h2 {
+    margin-bottom: 8px;
+    margin-top: 32px;
+  }
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .MarkdownBody h2 {
+    font-size: calc( 30.0697899531px + 4.0397585663 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .MarkdownBody h2 {
+    font-size: calc( 34.1095485194px + 1.8027503053 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .MarkdownBody h2 {
+    font-size: 35.9122988248px;
+  }
+}
+.MarkdownBody h2:target {
+  color: #745fb5;
+}
+
+.MarkdownBody h3 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 17.1925px;
+  font-weight: 400;
+  color: #745fb5;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .MarkdownBody h3 {
+    font-size: calc( 17.1925px + 1.6459 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .MarkdownBody h3 {
+    font-size: calc( 18.8384px + 0.3262 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .MarkdownBody h3 {
+    font-size: 19.1646px;
+  }
+}
+
+.MarkdownBody a,
+.MarkdownBody a:visited {
+  color: #26648e;
+  text-decoration: none;
+}
+.MarkdownBody a:hover {
+  text-decoration: underline;
+}
+.MarkdownBody em {
+  font-style: normal;
+  color: #556677;
+}
+.MarkdownBody iframe {
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.local-anchor {
+  margin-left: -0.9em;
+  margin-right: 0.1em;
+  padding: 0 0.1em;
+}
+.MarkdownBody .local-anchor, .MarkdownBody .local-anchor:visited {
+  color: #556677;
+  text-decoration: inherit;
+  opacity: 0.5;
+}
+.MarkdownBody .local-anchor:target, .MarkdownBody :target > .local-anchor {
+  color: #745fb5;
+  opacity: 1;
+}
+.MarkdownBody .local-anchor:hover, .MarkdownBody .local-anchor:focus {
+  color: white;
+  background: #745fb5;
+  opacity: 1;
+  text-decoration: inherit;
+}
+
+/*
+ * Crosslink (eg, phoenix.md)
+ */
+.MarkdownBody.MarkdownBody img {
+  max-width: 100%;
+}
+
+.MarkdownBody.MarkdownBody p.-crosslink > a {
+  display: block;
+  text-decoration: none;
+  color: #745fb5;
+  border-bottom: 0;
+  box-shadow: none;
+  margin: -16px;
+  padding: 16px;
+}
+.MarkdownBody.MarkdownBody p.-crosslink > a:visited {
+  color: #745fb5;
+}
+.MarkdownBody.MarkdownBody p.-crosslink > a::before {
+  content: "";
+  display: inline-block;
+  vertical-align: middle;
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22512%22%20height%3D%22512%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(255%2C255%2C255)%22%20d%3D%22M85%20277.375h259.704L225.002%20397.077%20256%20427l171-171L256%2085l-29.922%2029.924%20118.626%20119.7H85v42.75z%22%2F%3E%3C%2Fsvg%3E") center center/16px 16px no-repeat;
+  height: 16px;
+  width: 16px;
+  margin-right: 16px;
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  border-radius: 50%;
+}
+.MarkdownBody.MarkdownBody p.-crosslink > a::before, .MarkdownBody.MarkdownBody p.-crosslink > a:visited::before {
+  background-color: #745fb5;
+  color: white;
+}
+.MarkdownBody.MarkdownBody p.-crosslink > a:hover, .MarkdownBody.MarkdownBody p.-crosslink > a:focus {
+  color: #673d85;
+}
+.MarkdownBody.MarkdownBody p.-crosslink > a:hover::before, .MarkdownBody.MarkdownBody p.-crosslink > a:focus::before {
+  background-color: #673d85;
+}
+
+/*
+ * Table
+ */
+.MarkdownBody table {
+  /* Horizontal lines */
+}
+.MarkdownBody table {
+  width: 100%;
+}
+.MarkdownBody table tr + tr {
+  border-top: solid 1px rgba(85, 102, 119, 0.18);
+}
+.MarkdownBody table tbody + tbody {
+  border-top: solid 1px rgba(85, 102, 119, 0.3);
+}
+.MarkdownBody table td, .MarkdownBody table th {
+  padding: 8px 16px;
+  vertical-align: top;
+  text-align: left;
+}
+.MarkdownBody table tr th:last-child, .MarkdownBody table tr td:last-child {
+  text-align: right;
+}
+.MarkdownBody table td:first-child {
+  white-space: nowrap;
+}
+.MarkdownBody table td > code {
+  font-size: 0.96em;
+}
+.MarkdownBody table td:first-child > code {
+  color: #35a;
+}
+.MarkdownBody table a, .MarkdownBody table a:visited {
+  color: #35a;
+  text-decoration: none;
+}
+.MarkdownBody table td:first-child > code ~ em {
+  font-size: 11.3043478261px;
+  font-style: normal;
+  color: #556677;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .MarkdownBody table td:first-child > code ~ em {
+    font-size: calc( 11.3043478261px + 0.7646176912 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .MarkdownBody table td:first-child > code ~ em {
+    font-size: calc( 12.0689655172px + -0.1031535514 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .MarkdownBody table td:first-child > code ~ em {
+    font-size: 11.9658119658px;
+  }
+}
+.MarkdownBody table thead {
+  display: none;
+}
+.MarkdownBody table thead th {
+  font-weight: normal;
+  color: #745fb5;
+}
+
+.MarkdownBody table.-shortcuts td:first-child > code {
+  font-size: 1rem;
+  padding: 5px 6px;
+  padding-left: 8px;
+  background: #f8f9fa;
+  border-radius: 3px;
+  margin-right: 2px;
+  letter-spacing: 0.1em;
+  color: #345;
+}
+
+.MarkdownBody table.-shortcuts-right td:last-child > code {
+  font-size: 1rem;
+  padding: 5px 6px;
+  padding-left: 8px;
+  background: #f8f9fa;
+  border-radius: 3px;
+  margin-right: 2px;
+  letter-spacing: 0.1em;
+  color: #345;
+}
+
+.MarkdownBody table.-left-align tr th, .MarkdownBody table.-left-align tr td, .MarkdownBody table.-left-align tr td:last-child {
+  text-align: left;
+}
+
+.MarkdownBody table.-headers thead {
+  display: table-header-group;
+  border-bottom: solid 1px rgba(85, 102, 119, 0.3);
+}
+
+/*
+ * Key-value pairs (like in css)
+ */
+.MarkdownBody table.-key-values tbody tr td + td code {
+  display: block;
+  text-align: left;
+}
+
+.MarkdownBody table.-css-breakdown tr th, .MarkdownBody table.-css-breakdown tr td, .MarkdownBody table.-css-breakdown tr td:last-child {
+  text-align: left;
+}
+.MarkdownBody table.-css-breakdown tr td {
+  font-size: 14.95px;
+  white-space: nowrap;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .MarkdownBody table.-css-breakdown tr td {
+    font-size: calc( 14.95px + 1.29 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .MarkdownBody table.-css-breakdown tr td {
+    font-size: calc( 16.24px + 0.14 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .MarkdownBody table.-css-breakdown tr td {
+    font-size: 16.38px;
+  }
+}
+.MarkdownBody table.-css-breakdown tr td:not(:last-child) {
+  padding-right: 4px;
+}
+.MarkdownBody table.-css-breakdown tr td:not(:first-child) {
+  padding-left: 4px;
+}
+.MarkdownBody table.-css-breakdown tr:last-child {
+  background: #f8f9fa;
+}
+.MarkdownBody table.-css-breakdown tr:last-child td {
+  font-size: 11.3043478261px;
+  color: #556677;
+  white-space: auto;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .MarkdownBody table.-css-breakdown tr:last-child td {
+    font-size: calc( 11.3043478261px + 0.7646176912 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .MarkdownBody table.-css-breakdown tr:last-child td {
+    font-size: calc( 12.0689655172px + -0.1031535514 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .MarkdownBody table.-css-breakdown tr:last-child td {
+    font-size: 11.9658119658px;
+  }
+}
+
+.MarkdownBody table.-bold-first tr > td:first-child {
+  font-weight: bold;
+}
+
+.MarkdownBody table.-no-wrap td, .MarkdownBody table.-no-wrap th {
+  white-space: nowrap;
+}
+
+.MarkdownBody table.-mute-em td em, .MarkdownBody table.-mute-em th em {
+  opacity: 0.5;
+}
+.MarkdownBody table.-mute-em td em > code, .MarkdownBody table.-mute-em th em > code {
+  margin-right: 0.5em;
+}
+
+/* Separators (rehype-table-separators) */
+.MarkdownBody table tr.separator > td {
+  padding: 0;
+  height: 4px;
+  background: rgba(85, 102, 119, 0.18);
+  box-shadow: inset 0 1px 0 rgba(85, 102, 119, 0.3), inset 0 2px 4px rgba(85, 102, 119, 0.18);
+}
+
+.MarkdownBody ul.-six-column {
+  display: flex;
+  flex-wrap: wrap;
+}
+.MarkdownBody ul.-six-column > li {
+  flex: 0 0 16.6666666667%;
+}
+@media (max-width: 480px) {
+  .MarkdownBody ul.-six-column > li {
+    flex: 0 0 50%;
+  }
+}
+@media (max-width: 768px) {
+  .MarkdownBody ul.-six-column > li {
+    flex: 0 0 25%;
+  }
+}
+
+.MarkdownBody ul.-four-column {
+  display: flex;
+  flex-wrap: wrap;
+}
+.MarkdownBody ul.-four-column > li {
+  flex: 0 0 25%;
+}
+@media (max-width: 480px) {
+  .MarkdownBody ul.-four-column > li {
+    flex: 0 0 50%;
+  }
+}
+@media (max-width: 768px) {
+  .MarkdownBody ul.-four-column > li {
+    flex: 0 0 33.3333333333%;
+  }
+}
+
+/*
+ * Home link
+ */
+.back-button {
+  text-decoration: none;
+  width: 48px;
+  height: 48px;
+  line-height: 46px;
+  text-align: center;
+  display: inline-block;
+  border-radius: 50%;
+  transition: all 100ms linear;
+}
+@media (max-width: 480px) {
+  .back-button {
+    width: 32px;
+    height: 32px;
+    line-height: 30px;
+  }
+}
+.back-button, .back-button:visited {
+  color: #556677;
+}
+.back-button:hover, .back-button:focus {
+  color: white;
+  background: #745fb5;
+  opacity: 1;
+}
+.back-button::before {
+  content: "";
+  display: inline-block;
+  vertical-align: middle;
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22512%22%20height%3D%22512%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(51%2C68%2C85)%22%20d%3D%22M427%20234.625H167.296l119.702-119.702L256%2085%2085%20256l171%20171%2029.922-29.924-118.626-119.7H427v-42.75z%22%2F%3E%3C%2Fsvg%3E") center center/24px 24px no-repeat;
+  height: 24px;
+  width: 24px;
+  vertical-align: middle;
+}
+.back-button:hover::before, .back-button:focus::before {
+  display: inline-block;
+  vertical-align: middle;
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22512%22%20height%3D%22512%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(255%2C255%2C255)%22%20d%3D%22M427%20234.625H167.296l119.702-119.702L256%2085%2085%20256l171%20171%2029.922-29.924-118.626-119.7H427v-42.75z%22%2F%3E%3C%2Fsvg%3E") center center/24px 24px no-repeat;
+  height: 24px;
+  width: 24px;
+}
+@media (max-width: 480px) {
+  .back-button::before {
+    font-size: 16px;
+  }
+}
+
+.body-area {
+  max-width: 1232px;
+  margin: 0 auto;
+  padding: 16px;
+}
+@media (max-width: 480px) {
+  .body-area {
+    padding: 16px;
+  }
+}
+.body-area.-slim {
+  max-width: 740px;
+}
+
+/*
+ * H3 section
+ */
+.h3-section > .body {
+  /* Collapse/flush */
+  /* Border radius */
+}
+.h3-section > .body > pre, .h3-section > .body > .gatsby-highlight > pre {
+  margin: 0;
+  padding: 16px;
+}
+@media (max-width: 768px) {
+  .h3-section > .body {
+    overflow-x: auto;
+  }
+}
+.h3-section > .body {
+  background: white;
+  box-shadow: 0 6px 8px rgba(85, 102, 119, 0.03), 0 1px 1px rgba(85, 102, 119, 0.4);
+}
+@media (max-width: 480px) {
+  .h3-section > .body {
+    margin: 0 -16px;
+    box-shadow: 0 1px 1px rgba(85, 102, 119, 0.55);
+  }
+}
+@media (min-width: 481px) {
+  .h3-section > .body {
+    border-radius: 2px;
+  }
+  .h3-section > .body > :first-child {
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+  }
+  .h3-section > .body > :last-child {
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+  }
+}
+
+/*
+ * Heading
+ */
+.h3-section > h3 {
+  margin-top: 8px;
+  margin-bottom: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+@media (max-width: 768px) {
+  .h3-section > h3 {
+    margin-top: 0;
+  }
+}
+.h3-section > h3::after {
+  margin-left: 24px;
+  content: "";
+  display: inline-block;
+  vertical-align: middle;
+  width: 100%;
+  height: 1px;
+  background: linear-gradient(to right, rgba(116, 95, 181, 0.2), transparent 80%);
+}
+
+/*
+ * Children
+ */
+.h3-section > .body {
+  /* Lists */
+  /* Paragraphs */
+  /* Headings in between bodies */
+  /* Description paragraphs */
+}
+.h3-section > .body > ul {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+.h3-section > .body > ul > li {
+  padding: 8px;
+  padding-left: 36px;
+  position: relative;
+}
+.h3-section > .body > ul > li > p {
+  margin: 0;
+  padding: 0;
+}
+.h3-section > .body > ul > li::before {
+  content: "";
+  position: absolute;
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  background: #556677;
+  border-radius: 50%;
+  left: 16px;
+  top: 18px;
+}
+.h3-section > .body > ul > li + li {
+  border-top: solid 1px rgba(85, 102, 119, 0.18);
+}
+.h3-section > .body > p {
+  padding: 16px;
+  margin: 0;
+}
+.h3-section > .body > h4 {
+  font-size: 11.3043478261px;
+  margin: 0;
+  padding: 4px 16px;
+  font-weight: normal;
+  background: #f8f9fa;
+  color: #556677;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .h3-section > .body > h4 {
+    font-size: calc( 11.3043478261px + 0.7646176912 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .h3-section > .body > h4 {
+    font-size: calc( 12.0689655172px + -0.1031535514 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .h3-section > .body > h4 {
+    font-size: 11.9658119658px;
+  }
+}
+.h3-section > .body > h4 + * {
+  border-top: solid 1px rgba(85, 102, 119, 0.18);
+}
+.h3-section > .body p {
+  background: #f8f9fa;
+  color: #345;
+  /* Links */
+}
+.h3-section > .body p a, .h3-section > .body p a:visited {
+  color: #345;
+  text-decoration: none;
+  border-bottom: solid 1px rgba(85, 102, 119, 0.18);
+}
+.h3-section > .body p a:hover {
+  color: #26648e;
+}
+.h3-section > .body > *:not(:first-child) {
+  border-top: solid 1px rgba(85, 102, 119, 0.18);
+}
+.h3-section > .body > p + p, .h3-section > .body > p + p:not(:first-child) {
+  margin-top: -1.5em;
+  border-top: 0;
+}
+
+/*
+ * Variant: Prime
+ */
+@media (min-width: 481px) {
+  .h3-section.-prime > .body {
+    border-radius: 2px;
+    box-shadow: 0 6px 8px rgba(85, 102, 119, 0.03), 0 1px 1px rgba(85, 102, 119, 0.4), 0 8px 12px rgba(58, 193, 203, 0.1);
+  }
+}
+
+/*
+ * Variant: Also see :\
+ */
+ul.-also-see.-also-see.-also-see {
+  display: flex;
+  flex-wrap: wrap;
+  background: #f8f9fa;
+}
+ul.-also-see.-also-see.-also-see > li {
+  flex: 1 0 20%;
+  padding: 24px;
+  border-top: solid 1px rgba(85, 102, 119, 0.3);
+}
+ul.-also-see.-also-see.-also-see > li + li {
+  border-left: solid 1px rgba(85, 102, 119, 0.3);
+}
+ul.-also-see.-also-see.-also-see, ul.-also-see.-also-see.-also-see > li {
+  list-style-type: none;
+}
+ul.-also-see.-also-see.-also-see > li::before {
+  display: none;
+}
+ul.-also-see.-also-see.-also-see > li > a {
+  font-size: 14.95px;
+  display: block;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  ul.-also-see.-also-see.-also-see > li > a {
+    font-size: calc( 14.95px + 1.29 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  ul.-also-see.-also-see.-also-see > li > a {
+    font-size: calc( 16.24px + 0.14 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  ul.-also-see.-also-see.-also-see > li > a {
+    font-size: 16.38px;
+  }
+}
+ul.-also-see.-also-see.-also-see > li > em {
+  font-size: 11.3043478261px;
+  display: block;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  ul.-also-see.-also-see.-also-see > li > em {
+    font-size: calc( 11.3043478261px + 0.7646176912 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  ul.-also-see.-also-see.-also-see > li > em {
+    font-size: calc( 12.0689655172px + -0.1031535514 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  ul.-also-see.-also-see.-also-see > li > em {
+    font-size: 11.9658119658px;
+  }
+}
+
+.h3-section.-intro > .body > p {
+  font-size: 14.95px;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .h3-section.-intro > .body > p {
+    font-size: calc( 14.95px + 1.29 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .h3-section.-intro > .body > p {
+    font-size: calc( 16.24px + 0.14 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .h3-section.-intro > .body > p {
+    font-size: 16.38px;
+  }
+}
+.h3-section.-intro > .body > ul > li {
+  padding-left: 16px;
+  position: relative;
+}
+.h3-section.-intro > .body > ul > li::before {
+  display: none;
+}
+.h3-section.-intro > .body > ul > li > a {
+  font-size: 14.95px;
+  display: block;
+  font-weight: bold;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .h3-section.-intro > .body > ul > li > a {
+    font-size: calc( 14.95px + 1.29 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .h3-section.-intro > .body > ul > li > a {
+    font-size: calc( 16.24px + 0.14 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .h3-section.-intro > .body > ul > li > a {
+    font-size: 16.38px;
+  }
+}
+.h3-section.-intro > .body > ul > li > a::before {
+  content: "";
+  display: inline-block;
+  vertical-align: middle;
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22512%22%20height%3D%22512%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(150%2C155%2C207)%22%20d%3D%22M85%20277.375h259.704L225.002%20397.077%20256%20427l171-171L256%2085l-29.922%2029.924%20118.626%20119.7H85v42.75z%22%2F%3E%3C%2Fsvg%3E") center center/24px 24px no-repeat;
+  height: 24px;
+  width: 24px;
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  margin-top: -12px;
+}
+.h3-section.-intro > .body > ul > li:hover > a::before {
+  display: inline-block;
+  vertical-align: middle;
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22512%22%20height%3D%22512%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(116%2C95%2C181)%22%20d%3D%22M85%20277.375h259.704L225.002%20397.077%20256%20427l171-171L256%2085l-29.922%2029.924%20118.626%20119.7H85v42.75z%22%2F%3E%3C%2Fsvg%3E") center center/24px 24px no-repeat;
+  height: 24px;
+  width: 24px;
+}
+.h3-section.-intro > .body > ul > li > a::after {
+  content: "";
+  position: absolute;
+  display: block;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+.h3-section.-intro > .body > ul > li em {
+  color: #556677;
+}
+
+/*
+ * H3 section list:
+ * The body that is isotoped.
+ */
+.h3-section-list {
+  margin-left: -16px;
+  margin-right: -16px;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+@media (max-width: 1264px) {
+  .h3-section-list {
+    margin-left: -8px;
+  }
+}
+@media (max-width: 1264px) {
+  .h3-section-list {
+    margin-right: -8px;
+  }
+}
+.h3-section-list::after {
+  content: "";
+  display: table;
+  clear: both;
+  zoom: 1;
+}
+.h3-section-list > .h3-section {
+  padding: 16px;
+  float: left;
+  width: 100%;
+}
+@media (max-width: 1264px) {
+  .h3-section-list > .h3-section {
+    padding: 8px;
+  }
+}
+@media (min-width: 769px) {
+  .h3-section-list > .h3-section {
+    padding-top: 0;
+  }
+}
+
+/*
+ * Two column (default)
+ */
+@media (min-width: 769px) {
+  .h3-section-list > .h3-section,
+.h3-section-list.-two-column > .h3-section {
+    width: 50%;
+  }
+}
+
+/*
+ * One column
+ */
+.h3-section-list.-one-column > .h3-section {
+  width: 100%;
+}
+.h3-section-list.-one-column > .h3-section + .h3-section {
+  margin-top: 16px;
+}
+
+/*
+ * Three column
+ */
+@media (min-width: 769px) {
+  .h3-section-list.-three-column > .h3-section {
+    width: 50%;
+  }
+}
+@media (min-width: 961px) {
+  .h3-section-list.-three-column > .h3-section {
+    width: 33.33%;
+  }
+}
+
+/*
+ * Three column, left reference
+ */
+@media (min-width: 769px) {
+  .h3-section-list.-left-reference > .h3-section {
+    width: 50%;
+  }
+}
+@media (min-width: 961px) {
+  .h3-section-list.-left-reference > .h3-section {
+    width: 66.67%;
+  }
+  .h3-section-list.-left-reference > .h3-section:first-child {
+    width: 33.33%;
+  }
+}
+
+/*
+ * Base carbon ads style
+ */
+/*
+ * Carbon ads
+ *
+ *     .HeadlinePub
+ *       div#carbonads
+ *         span
+ *           span.carbon-wrap
+ *             a.carbon-img > img
+ *             a.carbon-text {description}
+ *           a.carbon-poweredby {powered by Carbon}
+ */
+.HeadlinePub .carbon-img,
+.HeadlinePub .carbon-text,
+.HeadlinePub .carbon-poweredby {
+  text-decoration: none;
+}
+.HeadlinePub .carbon-text,
+.HeadlinePub .carbon-poweredby {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+.HeadlinePub .carbon-img > img {
+  width: 130px;
+  height: 100px;
+  box-shadow: 0 6px 8px rgba(85, 102, 119, 0.03), 0 1px 1px rgba(85, 102, 119, 0.4);
+  border-radius: 3px;
+  background: rgba(85, 102, 119, 0.2);
+  color: transparent;
+}
+.HeadlinePub .carbon-img:hover img {
+  transform: translate3d(0, -1px, 0);
+  box-shadow: 0 6px 8px rgba(85, 102, 119, 0.03), 0 1px 1px rgba(85, 102, 119, 0.4), 0 8px 12px rgba(58, 193, 203, 0.1);
+}
+.HeadlinePub .carbon-text,
+.HeadlinePub .carbon-text:visited {
+  color: #345;
+}
+.HeadlinePub .carbon-text::after {
+  content: "  ";
+}
+.HeadlinePub .carbon-text:hover,
+.HeadlinePub .carbon-poweredby:hover {
+  color: #26648e;
+}
+.HeadlinePub .carbon-poweredby,
+.HeadlinePub .carbon-poweredby:visited {
+  display: block;
+  margin-top: 8px;
+  white-space: nowrap;
+  color: #556677;
+}
+.HeadlinePub {
+  position: relative;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+.HeadlinePub #carbonads ~ .placeholder {
+  opacity: 0;
+  transition: opacity 250ms linear;
+  pointer-events: none;
+}
+.HeadlinePub > .placeholder {
+  background-image: linear-gradient(92deg, rgba(85, 102, 119, 0.1), rgba(85, 102, 119, 0.17) 15%, rgba(85, 102, 119, 0.1) 30%);
+  background-size: 450px 100%;
+  animation: 2.5s ease-in-out infinite placeholder-swish;
+  border-radius: 3px;
+  position: absolute;
+  display: block;
+}
+.HeadlinePub > .placeholder.-one {
+  left: 0;
+  top: 0;
+  width: 130px;
+  height: 100px;
+}
+.HeadlinePub > .placeholder.-two, .HeadlinePub > .placeholder.-three, .HeadlinePub > .placeholder.-four {
+  left: 154px;
+  top: 6px;
+  height: 8px;
+  width: 226px;
+}
+.HeadlinePub > .placeholder.-three {
+  top: 28px;
+}
+.HeadlinePub > .placeholder.-four {
+  top: 50px;
+  width: 63.28px;
+}
+.HeadlinePub #carbonads {
+  position: relative;
+  z-index: 1;
+}
+.HeadlinePub, .HeadlinePub > div > span {
+  display: block;
+  width: 380px;
+  height: 100px;
+  text-align: left;
+}
+.HighlightPubFirstLine .HeadlinePub > div > span:first-line {
+  font-weight: bold;
+}
+.HeadlinePub > div > span::after {
+  content: "";
+  display: table;
+  clear: both;
+  zoom: 1;
+}
+.HeadlinePub .carbon-img {
+  float: left;
+  margin-right: 24px;
+}
+
+#carbonads {
+  animation: 500ms ease-out pub-text-enter;
+}
+
+@keyframes placeholder-swish {
+  0% {
+    background-position: -150px 0%;
+  }
+  50% {
+    background-position: 300px 0%;
+  }
+  100% {
+    background-position: 300px 0%;
+  }
+}
+@keyframes pub-text-enter {
+  0% {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  100% {
+    opacity: 1;
+  }
+}
+/*
+ * The top-level heading
+ */
+.main-heading {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 24px;
+  margin-top: 64px;
+  position: relative;
+}
+@media (max-width: 768px) {
+  .main-heading {
+    margin-bottom: 8px;
+    margin-top: 32px;
+  }
+}
+@media (max-width: 480px) {
+  .main-heading {
+    margin-bottom: 8px;
+    margin-top: 32px;
+  }
+}
+.main-heading {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.main-heading > h1 {
+  font-size: 39.767297213px;
+  line-height: 1.2;
+  font-weight: 200;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  margin: 0;
+  text-align: center;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .main-heading > h1 {
+    font-size: calc( 39.767297213px + 6.1305112747 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .main-heading > h1 {
+    font-size: calc( 45.8978084877px + 3.2625373735 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .main-heading > h1 {
+    font-size: 49.1603458612px;
+  }
+}
+.main-heading > h1 > em {
+  font-style: normal;
+  color: #8899aa;
+}
+.main-heading > .pubbox {
+  margin-top: 16px;
+  text-align: center;
+}
+@media (min-width: 769px) {
+  .main-heading > .pubbox {
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+}
+
+@media (min-width: 769px) {
+  .UseCompactHeader .main-heading {
+    display: flex;
+    align-items: flex-end;
+    margin-bottom: 32px;
+  }
+  .UseCompactHeader .main-heading > h1 {
+    flex: 1 0 auto;
+    text-align: left;
+    padding-right: 32px;
+  }
+  .UseCompactHeader .main-heading > .pubbox {
+    flex: 0 0 auto;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
+/**
+ * Add some space in preview mode
+ */
+.PreviewMode .main-heading {
+  margin-top: 16px;
+}
+
+.page-actions {
+  margin: 0;
+  padding: 0;
+}
+.page-actions {
+  height: 32px;
+}
+.page-actions > .link.link > a {
+  display: inline-block;
+  height: 32px;
+  line-height: 32px;
+  vertical-align: top;
+  width: auto;
+}
+.page-actions > li {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+.page-actions > li > a, .page-actions > li > a:visited {
+  color: #556677;
+  text-decoration: none;
+}
+.page-actions > li > a:hover, .page-actions > li > a:focus {
+  color: #745fb5;
+}
+.page-actions > li > a:hover > .text, .page-actions > li > a:focus > .text {
+  color: #745fb5;
+}
+.page-actions > li > a > .text {
+  font-size: 11.3043478261px;
+  display: none;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .page-actions > li > a > .text {
+    font-size: calc( 11.3043478261px + 0.7646176912 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .page-actions > li > a > .text {
+    font-size: calc( 12.0689655172px + -0.1031535514 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .page-actions > li > a > .text {
+    font-size: 11.9658119658px;
+  }
+}
+.page-actions > li > a > .text.-visible {
+  display: inline;
+}
+.page-actions + .page-actions {
+  margin-left: 8px;
+}
+.page-actions > .facebook > a::before, .page-actions > .twitter > a::before, .page-actions > .github > a::before {
+  content: "";
+  vertical-align: middle;
+}
+.page-actions > .facebook > a::before {
+  display: inline-block;
+  vertical-align: middle;
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(51%2C68%2C85)%22%20d%3D%22M426.8%2064H85.2C73.5%2064%2064%2073.5%2064%2085.2v341.6c0%2011.7%209.5%2021.2%2021.2%2021.2H256V296h-45.9v-56H256v-41.4c0-49.6%2034.4-76.6%2078.7-76.6%2021.2%200%2044%201.6%2049.3%202.3v51.8h-35.3c-24.1%200-28.7%2011.4-28.7%2028.2V240h57.4l-7.5%2056H320v152h106.8c11.7%200%2021.2-9.5%2021.2-21.2V85.2c0-11.7-9.5-21.2-21.2-21.2z%22%2F%3E%3C%2Fsvg%3E") center center/16px 16px no-repeat;
+  height: 16px;
+  width: 16px;
+}
+.page-actions > .twitter > a::before {
+  display: inline-block;
+  vertical-align: middle;
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22512%22%20height%3D%22512%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(51%2C68%2C85)%22%20d%3D%22M492%20109.5c-17.4%207.7-36%2012.9-55.6%2015.3%2020-12%2035.4-31%2042.6-53.6-18.7%2011.1-39.4%2019.2-61.5%2023.5C399.8%2075.8%20374.6%2064%20346.8%2064c-53.5%200-96.8%2043.4-96.8%2096.9%200%207.6.8%2015%202.5%2022.1-80.5-4-151.9-42.6-199.6-101.3-8.3%2014.3-13.1%2031-13.1%2048.7%200%2033.6%2017.2%2063.3%2043.2%2080.7-16-.4-31-4.8-44-12.1v1.2c0%2047%2033.4%2086.1%2077.7%2095-8.1%202.2-16.7%203.4-25.5%203.4-6.2%200-12.3-.6-18.2-1.8%2012.3%2038.5%2048.1%2066.5%2090.5%2067.3-33.1%2026-74.9%2041.5-120.3%2041.5-7.8%200-15.5-.5-23.1-1.4C62.8%20432%20113.7%20448%20168.3%20448%20346.6%20448%20444%20300.3%20444%20172.2c0-4.2-.1-8.4-.3-12.5C462.6%20146%20479%20129%20492%20109.5z%22%2F%3E%3C%2Fsvg%3E") center center/16px 16px no-repeat;
+  height: 16px;
+  width: 16px;
+}
+.page-actions > .github > a::before {
+  display: inline-block;
+  vertical-align: middle;
+  background: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22512%22%20height%3D%22512%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(51%2C68%2C85)%22%20d%3D%22M256%2032C132.3%2032%2032%20134.9%2032%20261.7c0%20101.5%2064.2%20187.5%20153.2%20217.9%201.4.3%202.6.4%203.8.4%208.3%200%2011.5-6.1%2011.5-11.4%200-5.5-.2-19.9-.3-39.1-8.4%201.9-15.9%202.7-22.6%202.7-43.1%200-52.9-33.5-52.9-33.5-10.2-26.5-24.9-33.6-24.9-33.6-19.5-13.7-.1-14.1%201.4-14.1h.1c22.5%202%2034.3%2023.8%2034.3%2023.8%2011.2%2019.6%2026.2%2025.1%2039.6%2025.1%2010.5%200%2020-3.4%2025.6-6%202-14.8%207.8-24.9%2014.2-30.7-49.7-5.8-102-25.5-102-113.5%200-25.1%208.7-45.6%2023-61.6-2.3-5.8-10-29.2%202.2-60.8%200%200%201.6-.5%205-.5%208.1%200%2026.4%203.1%2056.6%2024.1%2017.9-5.1%2037-7.6%2056.1-7.7%2019%20.1%2038.2%202.6%2056.1%207.7%2030.2-21%2048.5-24.1%2056.6-24.1%203.4%200%205%20.5%205%20.5%2012.2%2031.6%204.5%2055%202.2%2060.8%2014.3%2016.1%2023%2036.6%2023%2061.6%200%2088.2-52.4%20107.6-102.3%20113.3%208%207.1%2015.2%2021.1%2015.2%2042.5%200%2030.7-.3%2055.5-.3%2063%200%205.4%203.1%2011.5%2011.4%2011.5%201.2%200%202.6-.1%204-.4C415.9%20449.2%20480%20363.1%20480%20261.7%20480%20134.9%20379.7%2032%20256%2032z%22%2F%3E%3C%2Fsvg%3E") center center/16px 16px no-repeat;
+  height: 16px;
+  width: 16px;
+}
+.page-actions > .github > a:hover::before {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22512%22%20height%3D%22512%22%20viewBox%3D%220%200%20512%20512%22%3E%3Cpath%20fill%3D%22rgb(255%2C255%2C255)%22%20d%3D%22M256%2032C132.3%2032%2032%20134.9%2032%20261.7c0%20101.5%2064.2%20187.5%20153.2%20217.9%201.4.3%202.6.4%203.8.4%208.3%200%2011.5-6.1%2011.5-11.4%200-5.5-.2-19.9-.3-39.1-8.4%201.9-15.9%202.7-22.6%202.7-43.1%200-52.9-33.5-52.9-33.5-10.2-26.5-24.9-33.6-24.9-33.6-19.5-13.7-.1-14.1%201.4-14.1h.1c22.5%202%2034.3%2023.8%2034.3%2023.8%2011.2%2019.6%2026.2%2025.1%2039.6%2025.1%2010.5%200%2020-3.4%2025.6-6%202-14.8%207.8-24.9%2014.2-30.7-49.7-5.8-102-25.5-102-113.5%200-25.1%208.7-45.6%2023-61.6-2.3-5.8-10-29.2%202.2-60.8%200%200%201.6-.5%205-.5%208.1%200%2026.4%203.1%2056.6%2024.1%2017.9-5.1%2037-7.6%2056.1-7.7%2019%20.1%2038.2%202.6%2056.1%207.7%2030.2-21%2048.5-24.1%2056.6-24.1%203.4%200%205%20.5%205%20.5%2012.2%2031.6%204.5%2055%202.2%2060.8%2014.3%2016.1%2023%2036.6%2023%2061.6%200%2088.2-52.4%20107.6-102.3%20113.3%208%207.1%2015.2%2021.1%2015.2%2042.5%200%2030.7-.3%2055.5-.3%2063%200%205.4%203.1%2011.5%2011.4%2011.5%201.2%200%202.6-.1%204-.4C415.9%20449.2%20480%20363.1%20480%20261.7%20480%20134.9%20379.7%2032%20256%2032z%22%2F%3E%3C%2Fsvg%3E");
+}
+.page-actions > .facebook > a::before, .page-actions > .twitter > a::before {
+  width: 32px;
+  height: 32px;
+}
+.page-actions > .github > a::before {
+  position: relative;
+  top: -2px;
+}
+.page-actions > .link.-button > a {
+  box-shadow: inset 0 0 0 1px rgba(85, 102, 119, 0.3);
+  border-radius: 2px;
+  padding: 0 16px;
+  margin: 0 8px;
+  transition: all 100ms linear;
+}
+.page-actions > .link.-button > a > .text {
+  margin-left: 4px;
+  position: relative;
+  top: -1px;
+}
+.page-actions > .link.-button > a:hover, .page-actions > .link.-button > a:focus {
+  background: linear-gradient(5deg, #745fb5, #9066b8);
+  box-shadow: 0 1px 1px rgba(85, 102, 119, 0.55);
+}
+.page-actions > .link.-button > a:hover, .page-actions > .link.-button > a:hover > .text, .page-actions > .link.-button > a:focus, .page-actions > .link.-button > a:focus > .text {
+  color: white;
+}
+@media (max-width: 768px) {
+  .page-actions > .link {
+    margin-left: 16px;
+  }
+}
+.page-actions > .link:first-child > a {
+  margin-left: 0;
+}
+.page-actions > .link:last-child > a {
+  margin-right: 0;
+}
+
+.top-nav, .top-nav > .container {
+  height: 64px;
+  line-height: 64px;
+  text-align: center;
+  position: relative;
+}
+@media (max-width: 480px) {
+  .top-nav > .container {
+    height: 32px;
+    line-height: 32px;
+    margin-top: 8px;
+  }
+  .top-nav {
+    height: 48px;
+    padding: 8px 0;
+    border-bottom: solid 1px rgba(85, 102, 119, 0.3);
+    margin-bottom: 8px;
+  }
+}
+.top-nav > .container {
+  padding-left: 16px;
+  padding-right: 16px;
+  max-width: 1232px;
+  margin: 0 auto;
+}
+@media (max-width: 480px) {
+  .top-nav > .container {
+    padding-left: 16px;
+  }
+}
+@media (max-width: 480px) {
+  .top-nav > .container {
+    padding-right: 16px;
+  }
+}
+
+.top-nav > .container {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+.top-nav > .container > .left {
+  flex: 0 0 auto;
+  line-height: 32px;
+}
+.top-nav > .container > .brand {
+  flex: 1 1 auto;
+}
+.top-nav > .container > .actions {
+  flex: 0 0 auto;
+  display: flex;
+}
+.top-nav > .container > .brand {
+  font-size: 11.3043478261px;
+  display: inline-block;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-decoration: none;
+}
+@media (min-width: 480px) and (max-width: 768px) {
+  .top-nav > .container > .brand {
+    font-size: calc( 11.3043478261px + 0.7646176912 * ( ( 100vw - 480px) / 288 ) );
+  }
+}
+@media (min-width: 768px) and (max-width: 1280px) {
+  .top-nav > .container > .brand {
+    font-size: calc( 12.0689655172px + -0.1031535514 * ( ( 100vw - 768px) / 512 ) );
+  }
+}
+@media (min-width: 1280px) {
+  .top-nav > .container > .brand {
+    font-size: 11.9658119658px;
+  }
+}
+.top-nav > .container > .brand, .top-nav > .container > .brand:visited {
+  color: #345;
+}
+.top-nav > .container > .brand:hover {
+  color: #745fb5;
+}
+@media (max-width: 480px) {
+  .top-nav > .container > .brand {
+    display: none;
+  }
+  .top-nav > .container > .actions {
+    margin-left: auto;
+  }
+}
+@media (min-width: 481px) {
+  .top-nav > .container > .actions {
+    position: absolute;
+    right: 16px;
+    top: 16px;
+  }
+}
+@media (min-width: 481px) and (max-width: 480px) {
+  .top-nav > .container > .actions {
+    right: 16px;
+  }
+}
+@media (min-width: 481px) {
+  .top-nav > .container > .left {
+    position: absolute;
+    left: 16px;
+    top: 16px;
+  }
+}
+@media (min-width: 481px) and (max-width: 480px) {
+  .top-nav > .container > .left {
+    left: 16px;
+  }
+}
+@media (min-width: 1232px) {
+  .top-nav > .container > .left > .home {
+    position: relative;
+    left: -16px;
+  }
+}</style>
+
+<!-- allow disabling critical CSS optimization by passing ?nocrit=1 -->
+<script id='critical-css-disable'>if (~window.location.search.indexOf('nocrit')){;[].slice.call(document.querySelectorAll('#critical-css')).map(function(e){e.parentNode.removeChild(e)})}</script>
+
+<!-- deferred css -->
+<script id='deferred-css'>;(function(links){(requestAnimationFrame||mozRequestAnimationFrame||webkitRequestAnimationFrame||msRequestAnimationFrame||(function(fn){window.addEventListener('load',fn)}))(function(){var h=document.getElementsByTagName('head')[0],l,i;for (i=0;i<links.length;i++){l=document.createElement('link');l.rel='stylesheet';l.href=links[i];h.appendChild(l);}})})([
+'https://fonts.googleapis.com/css?family=Cousine',
+'./assets/2017/style.css?t=20230630061434'
+])</script>
+<noscript id='deferred-css-fallback'>
+<link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Cousine'>
+<link rel='stylesheet' href='./assets/2017/style.css?t=20230630061434'>
+</noscript>
+
+</head>
+
+<body class='UseCompactHeader HighlightPubFirstLine'>
+
+
+<div class='body-area'>
+  <header class='main-heading -center' role='banner'>
+    <h1 class='h1'>Codemagic.yaml <em>cheatsheet</em></h1>
+
+    <div class='pubbox' data-js-no-preview>
+      
+        <div class='HeadlinePub' role='complementary'>
+
+    </div>
+      
+    </div>
+  </header>
+  
+
+  <main class='post-content MarkdownBody' data-js-main-body data-js-anchors role='main'>
+    <h2 class="-three-column" id="getting-started">Getting started</h2>
+
+<h3 class="-intro" id="introduction">Introduction</h3>
+
+<p>This is a quick reference for using <code>codemagic.yaml</code>.</p>
+
+<ul>
+  <li><a href="https://docs.codemagic.io/yaml-basic-configuration/yaml-getting-started/">Full documentation for codemagic.yaml</a> <em>(https://docs.codemagic.io/yaml-basic-configuration/yaml-getting-started/)</em></li>
+</ul>
+
+<h3 id="reusing-sections">Reusing Sections</h3>
+
+<p>Define a section at the top of the .yaml file and reuse it later in different workflows.</p>
+
+<pre><code class="language-yaml">definitions:
+  instance_mac_pro: &amp;instance_mac_pro
+    instance_type: mac_pro
+    max_build_duration: 120
+  env_versions: &amp;env_versions
+    flutter: stable
+    xcode: latest
+    cocoapods: default
+  scripts:
+    - &amp;add_certs_to_keychain
+      name: Add certs to keychain
+      script: |
+         keychain add-certificates
+</code></pre>
+
+<p>Reuse the defined section elsewhere by adding a * in front of it.</p>
+
+<pre data-line="4,6,8"><code class="language-yaml">workflows:
+  ios-release:
+    name: iOS release
+    &lt;&lt;: *instance_mac_pro
+    environment:
+      &lt;&lt;: *env_versions
+    scripts:
+      - *add_certs_to_keychain
+</code></pre>
+
+<h3 id="decoding">Decoding</h3>
+
+<p>base64 decoding during build time in your scripts section using command:</p>
+
+<pre><code class="language-bash">echo $ENV_VAR | base64 --decode &gt; /path/afile
+</code></pre>
+
+<h3 id="encoding">Encoding</h3>
+
+<p>base64 encoding the confidential file and copying the result to clipboard.</p>
+
+<p>macOS:</p>
+<pre><code class="language-bash">cat your_file | base64 | pbcopy
+</code></pre>
+
+<p>Windows:</p>
+<pre><code class="language-powershell">[Convert]::ToBase64String([IO.File]::ReadAllBytes("file.ext")) | \
+Set-Clipboard
+</code></pre>
+
+<p>Linux:</p>
+<pre><code class="language-bash">sudo apt-get install xclip
+cat your_file | \
+base64 | \
+xclip -selection clipboard
+</code></pre>
+
+<h3 id="syntax">Syntax</h3>
+
+<pre><code class="language-yaml">workflows:
+  hello-world-workflow:
+    name: Hello world workflow
+    scripts:
+        - echo "Hello World!"
+</code></pre>
+
+<h2 class="-two-column" id="workflow-environment">Workflow environment</h2>
+
+<h3 id="global-environment-variable-groups">Global Environment variable groups</h3>
+
+<pre><code class="language-yaml">environment:
+  groups:             # Define your environment variables groups here
+    - keystore_credentials
+    - app_store_credentials
+    - firebase_credentials
+</code></pre>
+
+<blockquote>
+  <p>Tip: Store all the keystore variables in the same group so they can be imported to codemagic.yaml workflow at once.</p>
+</blockquote>
+
+<h3 id="workflow-specific-variables">Workflow specific variables</h3>
+<p>Define workflow-specific public environment variables:</p>
+
+<pre><code class="language-yaml">environment:
+  vars:             # Define your environment variables here
+    PUBLIC_ENV_VAR: "value here"
+</code></pre>
+
+<h3 id="software-versions">Software versions</h3>
+
+<pre><code class="language-yaml">environment:
+  flutter: stable  # Channel name or version (e.g. v1.13.4)
+  xcode: latest    # Define latest, edge or version (e.g. 11.2)
+  cocoapods: 1.9.1 # Define default or version
+  node: 12.14.0    # Define default, latest, current, etc or version
+  npm: 6.13.7      # Define default, latest, next, lts or version
+  ndk: r21d        # Define default or ver, also define in build.gradle
+  java: 1.8        # Define default or platform version (e.g. 11)
+  ruby: 2.7.2      # Define default or version
+</code></pre>
+
+<h2 class="-two-column" id="triggering">Triggering</h2>
+
+<p><code>triggering</code>: defines the events for automatic build triggering and watched branches. If no events are defined, you can only start builds manually.</p>
+
+<h3 id="skip-building-a-specific-commit">Skip building a specific commit</h3>
+
+<p>Include <code>[skip ci]</code> or <code>[ci skip]</code> in a commit message to not build a particular commit.</p>
+
+<h3 id="trigger-on-push-to-any-branch">Trigger on push to any branch</h3>
+
+<pre><code class="language-yaml">triggering:
+  events:  
+    - push
+  branch_patterns:
+    - pattern: '*'
+</code></pre>
+
+<h3 id="exclude-dev-branch">Exclude <code>dev*</code> branch</h3>
+
+<pre><code class="language-yaml">triggering:
+  events:  
+    - push
+  branch_patterns:
+    - pattern: '*'		#default value for include is true
+    - pattern: 'dev*'
+    - include: false
+</code></pre>
+
+<h3 id="trigger-on-pr-created-from-any-branch-to-any-branch">Trigger on PR created from any branch to any branch</h3>
+
+<pre><code class="language-yaml">triggering:
+  events:  
+    - pull_request
+  branch_patterns:
+    - pattern: '*'
+</code></pre>
+
+<h3 id="trigger-on-pr-created-from-the-dev-branch-to-any-branch">Trigger on PR created from the <code>dev</code> branch to any branch</h3>
+
+<pre><code class="language-yaml">triggering:
+  events:  
+    - pull_request
+  branch_patterns:
+    - pattern: 'dev*'
+    - source: true		#source is true by default
+</code></pre>
+
+<h3 id="trigger-on-pr-created-from-the-dev-branch-to-any-branch-excluding-master">Trigger on PR created from the <code>dev</code> branch to any branch excluding <code>master</code></h3>
+
+<pre><code class="language-yaml">triggering:
+  events:  
+    - pull_request
+  Branch_patterns:
+    - pattern: 'dev*'
+    - source: false
+    - pattern: 'master'
+    - include: false
+</code></pre>
+
+<h3 id="trigger-on-pr-created-from-any-branch-to-dev">Trigger on PR created from any branch to <code>dev</code></h3>
+
+<pre><code class="language-yaml">triggering:
+  events:  
+    - pull_request
+  branch_patterns:
+    - pattern: 'dev*'
+    - source: false		#source is true by default
+</code></pre>
+
+<h3 id="trigger-on-push-and-pr-created-from-any-branch-and-cancel-outdated-webhook-builds">Trigger on push and PR created from any branch and cancel outdated webhook builds</h3>
+
+<p>2 builds will start: for push and PR. <code>cancel_previous_builds</code> will cancel out-dated webhook builds but applies for the next webhook <em>only</em>.</p>
+
+<pre><code class="language-yaml">triggering:
+  events:  
+    - push
+    - pull_request
+  branch_patterns:
+    - pattern: '*'
+  cancel_previous_builds: true
+</code></pre>
+
+<p>Avoid running builds on outdated commits by setting <code>cancel_previous_builds</code> to automatically cancel all ongoing and queued builds triggered by webhooks on push or pull request commit when a more recent build has been triggered for the same branch.</p>
+
+<h2 class="-two-column" id="conditional-build-triggers">Conditional Build Triggers</h2>
+
+<h3 id="trigger-on-file-changes">Trigger on file changes</h3>
+<p>Specify the files to watch in the <code>changeset</code> using the <code>includes</code> and <code>excludes</code> keys. Example skips builds for any <code>markdown</code> files:</p>
+
+<pre><code class="language-yaml">workflows:
+  build-app:
+    name: Build App
+    triggering:
+      events:
+        - push
+    when:
+      changeset:
+        includes:
+          - '.'     # default value '.'
+        excludes:
+          - '**/*.md'
+</code></pre>
+
+<h3 id="trigger-on-push-when-change-in-a-specific-path">Trigger on push when change in a specific path</h3>
+
+<pre><code class="language-yaml">workflows:
+  build-ios:
+    name: Build iOS
+    triggering:
+      events:
+        - push
+    when:
+      changeset:
+        includes:
+          - 'iOS/'
+</code></pre>
+
+<h3 id="trigger-event-using-when-condition">Trigger event using <code>when</code> condition</h3>
+
+<pre><code class="language-yaml">workflows:
+  build:
+    name: Build on PR update
+    triggering:
+      events:
+        - pull_request
+    when:
+      condition: not event.pull_request.draft
+</code></pre>
+
+<h2 class="-one-column" id="scripts">Scripts</h2>
+
+<h3 id="using-multiline-scripts">Using multiline scripts</h3>
+
+<pre><code class="language-yaml">scripts:
+  - echo "single line script"
+  - name: Flutter test
+    script: flutter test
+    ignore_failure: true
+  - | # use pipe to write a script in multiple lines. 
+    #!/usr/bin/env python3
+
+    print('Multiline python script')
+</code></pre>
+
+<h2 class="-two-column" id="build-versioning">Build Versioning</h2>
+
+<h3 id="flutter">Flutter</h3>
+<p>Increment build number and build name:</p>
+
+<pre><code class="language-bash">--build-name=1.0.$PROJECT_BUILD_NUMBER \
+--build-number=$PROJECT_BUILD_NUMBER
+</code></pre>
+
+<h3 id="native-ios">Native iOS</h3>
+
+<pre><code class="language-bash">set -e
+set -x
+cd $CM_BUILD_DIR/ios
+agvtool new-version -all $(($BUILD_NUMBER + 1))
+</code></pre>
+
+<h3 id="get-the-latest-build-number-from-app-store">Get the latest build number from App Store</h3>
+
+<pre><code class="language-bash">LATEST_BUILD=$(get-latest-app-store-build-number "$APP_ID")
+agvtool new-version -all $(($LATEST_BUILD + 1))
+</code></pre>
+<h3 id="get-the-latest-build-number-from-app-store-or-testflight">Get the latest build number from App Store or TestFlight</h3>
+
+<pre><code class="language-bash">LATEST_BUILD=$(app-store-connect get-latest-build-number "$APP_ID")
+agvtool new-version -all $(($LATEST_BUILD + 1))
+</code></pre>
+
+<h3 id="get-the-latest-build-number-from-testflight">Get the latest build number from TestFlight</h3>
+
+<pre><code class="language-bash">LATEST_BUILD=$(app-store-connect get-latest-testflight-build-number "$APP_ID")
+agvtool new-version -all $(($LATEST_BUILD + 1))
+</code></pre>
+
+<h2 class="-two-column" id="artifacts--publishing">Artifacts &amp; Publishing</h2>
+
+<h3 id="artifacts">Artifacts</h3>
+
+<p>All paths are relative to the clone directory, but absolute paths are supported as well. There are also environment variables for artifact patterns.</p>
+
+<pre><code class="language-yaml">artifacts:
+  - build/**/outputs/apk/**/*.apk  # path from root dir
+  - subfolder_name/build/**/outputs/apk/**/*.apk # path from subdir
+  - build/**/outputs/**/*.aab
+  - build/**/outputs/**/mapping.txt
+  - build/ios/ipa/*.ipa
+  - build/macos/**/*.pkg
+  - /tmp/xcodebuild_logs/*.log
+  - flutter_drive.log
+  - $HOME/Library/Developer/Xcode/DerivedData/**/Build/**/*.dSYM
+</code></pre>
+
+<h3 id="publishing">Publishing</h3>
+
+<p>Codemagic has a number of integrations for publishing, but you can also publish elsewhere with custom scripts.</p>
+
+<p>Note that the publishing scripts are run by default regardless of the build status. You can specify additional conditions with if statements.</p>
+
+<pre><code class="language-yaml">publishing:
+  email:
+    recipients:
+      - name@example.com
+  scripts:
+    name: Check for apk
+    script: |
+      apkPath=$(find build -name "*.apk" | head -1)
+      if [[ -z ${apkPath} ]]
+      then
+        echo "No .apk were found"
+      else
+        echo "Publishing .apk artifacts"
+      fi      
+</code></pre>
+
+<h3 id="report-build-status">Report build status</h3>
+
+<pre><code class="language-yaml">scripts:
+  - name: Report build start
+    script: # build started
+
+    . . .
+
+  - name: Build finished successfully
+    script: touch ~/SUCCESS
+publishing:
+  scripts:
+    - name: Report build status
+      script: |
+        if [ -a "~/SUCCESS" ] ; then
+           # build successful
+        else
+           # build failed
+        fi
+</code></pre>
+
+  </main>
+</div>
+
+
+<script>// modules are defined as an array
+// [ module function, map of requires ]
+//
+// map of requires is short require name -> numeric require
+//
+// anything defined in a previous bundle is accessed via the
+// orig method which is the require for previous bundles
+parcelRequire = (function (modules, cache, entry, globalName) {
+  // Save the require from previous bundle to this closure if any
+  var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
+  var nodeRequire = typeof require === 'function' && require;
+
+  function newRequire(name, jumped) {
+    if (!cache[name]) {
+      if (!modules[name]) {
+        // if we cannot find the module within our internal map or
+        // cache jump to the current global require ie. the last bundle
+        // that was added to the page.
+        var currentRequire = typeof parcelRequire === 'function' && parcelRequire;
+        if (!jumped && currentRequire) {
+          return currentRequire(name, true);
+        }
+
+        // If there are other bundles on this page the require from the
+        // previous one is saved to 'previousRequire'. Repeat this as
+        // many times as there are bundles until the module is found or
+        // we exhaust the require chain.
+        if (previousRequire) {
+          return previousRequire(name, true);
+        }
+
+        // Try the node require function if it exists.
+        if (nodeRequire && typeof name === 'string') {
+          return nodeRequire(name);
+        }
+
+        var err = new Error('Cannot find module \'' + name + '\'');
+        err.code = 'MODULE_NOT_FOUND';
+        throw err;
+      }
+
+      localRequire.resolve = resolve;
+      localRequire.cache = {};
+
+      var module = cache[name] = new newRequire.Module(name);
+
+      modules[name][0].call(module.exports, localRequire, module, module.exports, this);
+    }
+
+    return cache[name].exports;
+
+    function localRequire(x){
+      return newRequire(localRequire.resolve(x));
+    }
+
+    function resolve(x){
+      return modules[name][1][x] || x;
+    }
+  }
+
+  function Module(moduleName) {
+    this.id = moduleName;
+    this.bundle = newRequire;
+    this.exports = {};
+  }
+
+  newRequire.isParcelRequire = true;
+  newRequire.Module = Module;
+  newRequire.modules = modules;
+  newRequire.cache = cache;
+  newRequire.parent = previousRequire;
+  newRequire.register = function (id, exports) {
+    modules[id] = [function (require, module) {
+      module.exports = exports;
+    }, {}];
+  };
+
+  var error;
+  for (var i = 0; i < entry.length; i++) {
+    try {
+      newRequire(entry[i]);
+    } catch (e) {
+      // Save first error but execute all entries
+      if (!error) {
+        error = e;
+      }
+    }
+  }
+
+  if (entry.length) {
+    // Expose entry point to Node, AMD or browser globals
+    // Based on https://github.com/ForbesLindesay/umd/blob/master/template.js
+    var mainExports = newRequire(entry[entry.length - 1]);
+
+    // CommonJS
+    if (typeof exports === "object" && typeof module !== "undefined") {
+      module.exports = mainExports;
+
+    // RequireJS
+    } else if (typeof define === "function" && define.amd) {
+     define(function () {
+       return mainExports;
+     });
+
+    // <script>
+    } else if (globalName) {
+      this[globalName] = mainExports;
+    }
+  }
+
+  // Override the current require with this new one
+  parcelRequire = newRequire;
+
+  if (error) {
+    // throw error from earlier, _after updating parcelRequire_
+    throw error;
+  }
+
+  return newRequire;
+})({"../node_modules/dom101/matches.js":[function(require,module,exports) {
+/**
+ * matches : matches(el, selector)
+ * Checks if a given element `el` matches `selector`.
+ * Compare with [$.fn.is](http://api.jquery.com/is/).
+ *
+ *     var matches = require('dom101/matches');
+ *
+ *     matches(button, ':focus');
+ */
+
+function matches (el, selector) {
+  var _matches = el.matches ||
+    el.matchesSelector ||
+    el.msMatchesSelector ||
+    el.mozMatchesSelector ||
+    el.webkitMatchesSelector ||
+    el.oMatchesSelector
+
+  if (_matches) {
+    return _matches.call(el, selector)
+  } else if (el.parentNode) {
+    // IE8 and below
+    var nodes = el.parentNode.querySelectorAll(selector)
+    for (var i = nodes.length; i--; 0) {
+      if (nodes[i] === el) return true
+    }
+    return false
+  }
+}
+
+module.exports = matches
+
+},{}],"../node_modules/dom101/each.js":[function(require,module,exports) {
+/**
+ * each : each(list, fn)
+ * Iterates through `list` (an array or an object). This is useful when dealing
+ * with NodeLists like `document.querySelectorAll`.
+ *
+ *     var each = require('dom101/each');
+ *     var qa = require('dom101/query-selector-all');
+ *
+ *     each(qa('.button'), function (el) {
+ *       addClass('el', 'selected');
+ *     });
+ */
+
+function each (list, fn) {
+  var i
+  var len = list.length
+  var idx
+
+  if (typeof len === 'number') {
+    for (i = 0; i < len; i++) {
+      fn(list[i], i)
+    }
+  } else {
+    idx = 0
+    for (i in list) {
+      if (list.hasOwnProperty(i)) {
+        fn(list[i], i, idx++)
+      }
+    }
+  }
+
+  return list
+}
+
+module.exports = each
+
+},{}],"../node_modules/dom101/add-class.js":[function(require,module,exports) {
+var each = require('./each')
+
+/**
+ * addClass : addClass(el, className)
+ * Adds a class name to an element. Compare with `$.fn.addClass`.
+ *
+ *     var addClass = require('dom101/add-class');
+ *
+ *     addClass(el, 'active');
+ */
+
+function addClass (el, className) {
+  if (!className) return
+
+  if (Array.isArray(className)) {
+    each(className, function (className) {
+      addClass(el, className)
+    })
+
+    return
+  }
+
+  if (el.classList) {
+    var classNames = className.split(' ').filter(Boolean)
+    each(classNames, function (className) {
+      el.classList.add(className)
+    })
+  } else {
+    el.className += ' ' + className
+  }
+}
+
+module.exports = addClass
+
+},{"./each":"../node_modules/dom101/each.js"}],"helpers/dom.js":[function(require,module,exports) {
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.appendMany = appendMany;
+exports.nextUntil = nextUntil;
+exports.before = before;
+exports.findChildren = findChildren;
+exports.createDiv = createDiv;
+
+var _matches = _interopRequireDefault(require("dom101/matches"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+/*
+ * Just like jQuery.append
+ */
+function appendMany(el, children) {
+  children.forEach(function (child) {
+    el.appendChild(child);
+  });
+}
+/*
+ * Just like jQuery.nextUntil
+ */
+
+
+function nextUntil(el, selector) {
+  var nextEl = el.nextSibling;
+  return nextUntilTick(nextEl, selector, []);
+}
+
+function nextUntilTick(el, selector, acc) {
+  if (!el) return acc;
+  var isMatch = (0, _matches.default)(el, selector);
+  if (isMatch) return acc;
+  return nextUntilTick(el.nextSibling, selector, [].concat(_toConsumableArray(acc), [el]));
+}
+/*
+ * Just like jQuery.before
+ */
+
+
+function before(reference, newNode) {
+  reference.parentNode.insertBefore(newNode, reference);
+}
+/*
+ * Like jQuery.children('selector')
+ */
+
+
+function findChildren(el, selector) {
+  return [].slice.call(el.children).filter(function (child) {
+    return (0, _matches.default)(child, selector);
+  });
+}
+/**
+ * Creates a div
+ * @private
+ *
+ * @example
+ *
+ *     createDiv({ class: 'foo' })
+ */
+
+
+function createDiv(props) {
+  var d = document.createElement('div');
+  Object.keys(props).forEach(function (key) {
+    d.setAttribute(key, props[key]);
+  });
+  return d;
+}
+},{"dom101/matches":"../node_modules/dom101/matches.js"}],"wrapify/index.js":[function(require,module,exports) {
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = wrapify;
+exports.groupify = groupify;
+
+var _matches = _interopRequireDefault(require("dom101/matches"));
+
+var _addClass = _interopRequireDefault(require("dom101/add-class"));
+
+var _dom = require("../helpers/dom");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+/**
+ * Wraps h2 sections into h2-section.
+ * Wraps h3 sections into h3-section.
+ *
+ * @private
+ */
+function wrapify(root) {
+  // These are your H2 sections. Returns a list of .h2-section nodes.
+  var sections = wrapifyH2(root); // For each h2 section, wrap the H3's in them
+
+  sections.forEach(function (section) {
+    var bodies = (0, _dom.findChildren)(section, '[data-js-h3-section-list]');
+    bodies.forEach(function (body) {
+      wrapifyH3(body);
+    });
+  });
+}
+/**
+ * Wraps h2 sections into h2-section.
+ * Creates and HTML structure like so:
+ *
+ *     .h2-section
+ *       h2.
+ *         (title)
+ *       .body.h3-section-list.
+ *         (body goes here)
+ *
+ * @private
+ */
+
+
+function wrapifyH2(root) {
+  return groupify(root, {
+    tag: 'h2',
+    wrapperFn: function wrapperFn() {
+      return (0, _dom.createDiv)({
+        class: 'h2-section'
+      });
+    },
+    bodyFn: function bodyFn() {
+      return (0, _dom.createDiv)({
+        class: 'body h3-section-list',
+        'data-js-h3-section-list': ''
+      });
+    }
+  });
+}
+/**
+ * Wraps h3 sections into h3-section.
+ * Creates and HTML structure like so:
+ *
+ *     .h3-section
+ *       h3.
+ *         (title)
+ *       .body.
+ *         (body goes here)
+ *
+ * @private
+ */
+
+
+function wrapifyH3(root) {
+  return groupify(root, {
+    tag: 'h3',
+    wrapperFn: function wrapperFn() {
+      return (0, _dom.createDiv)({
+        class: 'h3-section'
+      });
+    },
+    bodyFn: function bodyFn() {
+      return (0, _dom.createDiv)({
+        class: 'body'
+      });
+    }
+  });
+}
+/**
+ * Groups all headings (a `tag` selector) under wrappers like `.h2-section`
+ * (build by `wrapperFn()`).
+ * @private
+ */
+
+
+function groupify(el, _ref) {
+  var tag = _ref.tag,
+      wrapperFn = _ref.wrapperFn,
+      bodyFn = _ref.bodyFn;
+  var first = el.children[0];
+  var result = []; // Handle the markup before the first h2
+
+  if (first && !(0, _matches.default)(first, tag)) {
+    var sibs = (0, _dom.nextUntil)(first, tag);
+    result.push(wrap(first, null, [first].concat(_toConsumableArray(sibs))));
+  } // Find all h3's inside it
+
+
+  var children = (0, _dom.findChildren)(el, tag);
+  children.forEach(function (child) {
+    var sibs = (0, _dom.nextUntil)(child, tag);
+    result.push(wrap(child, child, sibs));
+  });
+  return result;
+
+  function wrap(pivot, first, sibs) {
+    var wrap = wrapperFn();
+    var pivotClass = pivot.className;
+    if (pivotClass) (0, _addClass.default)(wrap, pivotClass);
+    (0, _dom.before)(pivot, wrap);
+    var body = bodyFn();
+    if (pivotClass) (0, _addClass.default)(body, pivotClass);
+    (0, _dom.appendMany)(body, sibs);
+    if (first) wrap.appendChild(first);
+    wrap.appendChild(body);
+    return wrap;
+  }
+}
+},{"dom101/matches":"../node_modules/dom101/matches.js","dom101/add-class":"../node_modules/dom101/add-class.js","../helpers/dom":"helpers/dom.js"}],"../node_modules/dom101/on.js":[function(require,module,exports) {
+/**
+ * on : on(el, event, fn)
+ * Adds an event handler.
+ *
+ *     var on = require('dom101/on');
+ *
+ *     on(el, 'click', function () {
+ *       ...
+ *     });
+ */
+
+function on (el, event, handler) {
+  if (el.addEventListener) {
+    el.addEventListener(event, handler)
+  } else {
+    el.attachEvent('on' + event, function () {
+      handler.call(el)
+    })
+  }
+}
+
+module.exports = on
+
+},{}],"critical.js":[function(require,module,exports) {
+"use strict";
+
+var _wrapify = _interopRequireDefault(require("./wrapify"));
+
+var _addClass = _interopRequireDefault(require("dom101/add-class"));
+
+var _on = _interopRequireDefault(require("dom101/on"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/*
+ * This is the "critical path" JavaScript that will be included INLINE on every
+ * page. Keep this as small as possible!
+ */
+// Transform the main body markup to make it readable.
+var body = document.querySelector('[data-js-main-body]');
+
+if (body) {
+  (0, _wrapify.default)(body);
+  (0, _addClass.default)(body, '-wrapified');
+} // Be "done" when we're done, or after a certain timeout.
+
+
+(0, _on.default)(window, 'load', done);
+setTimeout(done, 5000);
+var isDone;
+
+function done() {
+  if (isDone) return;
+  (0, _addClass.default)(document.documentElement, 'LoadDone');
+  isDone = true;
+}
+},{"./wrapify":"wrapify/index.js","dom101/add-class":"../node_modules/dom101/add-class.js","dom101/on":"../node_modules/dom101/on.js"}],"../node_modules/parcel-bundler/src/builtins/hmr-runtime.js":[function(require,module,exports) {
+var global = arguments[3];
+var OVERLAY_ID = '__parcel__error__overlay__';
+var OldModule = module.bundle.Module;
+
+function Module(moduleName) {
+  OldModule.call(this, moduleName);
+  this.hot = {
+    data: module.bundle.hotData,
+    _acceptCallbacks: [],
+    _disposeCallbacks: [],
+    accept: function (fn) {
+      this._acceptCallbacks.push(fn || function () {});
+    },
+    dispose: function (fn) {
+      this._disposeCallbacks.push(fn);
+    }
+  };
+  module.bundle.hotData = null;
+}
+
+module.bundle.Module = Module;
+var checkedAssets, assetsToAccept;
+var parent = module.bundle.parent;
+
+if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
+  var hostname = "" || location.hostname;
+  var protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+  var ws = new WebSocket(protocol + '://' + hostname + ':' + "32855" + '/');
+
+  ws.onmessage = function (event) {
+    checkedAssets = {};
+    assetsToAccept = [];
+    var data = JSON.parse(event.data);
+
+    if (data.type === 'update') {
+      var handled = false;
+      data.assets.forEach(function (asset) {
+        if (!asset.isNew) {
+          var didAccept = hmrAcceptCheck(global.parcelRequire, asset.id);
+
+          if (didAccept) {
+            handled = true;
+          }
+        }
+      }); // Enable HMR for CSS by default.
+
+      handled = handled || data.assets.every(function (asset) {
+        return asset.type === 'css' && asset.generated.js;
+      });
+
+      if (handled) {
+        console.clear();
+        data.assets.forEach(function (asset) {
+          hmrApply(global.parcelRequire, asset);
+        });
+        assetsToAccept.forEach(function (v) {
+          hmrAcceptRun(v[0], v[1]);
+        });
+      } else if (location.reload) {
+        // `location` global exists in a web worker context but lacks `.reload()` function.
+        location.reload();
+      }
+    }
+
+    if (data.type === 'reload') {
+      ws.close();
+
+      ws.onclose = function () {
+        location.reload();
+      };
+    }
+
+    if (data.type === 'error-resolved') {
+      console.log('[parcel] ✨ Error resolved');
+      removeErrorOverlay();
+    }
+
+    if (data.type === 'error') {
+      console.error('[parcel] 🚨  ' + data.error.message + '\n' + data.error.stack);
+      removeErrorOverlay();
+      var overlay = createErrorOverlay(data);
+      document.body.appendChild(overlay);
+    }
+  };
+}
+
+function removeErrorOverlay() {
+  var overlay = document.getElementById(OVERLAY_ID);
+
+  if (overlay) {
+    overlay.remove();
+  }
+}
+
+function createErrorOverlay(data) {
+  var overlay = document.createElement('div');
+  overlay.id = OVERLAY_ID; // html encode message and stack trace
+
+  var message = document.createElement('div');
+  var stackTrace = document.createElement('pre');
+  message.innerText = data.error.message;
+  stackTrace.innerText = data.error.stack;
+  overlay.innerHTML = '<div style="background: black; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; opacity: 0.85; font-family: Menlo, Consolas, monospace; z-index: 9999;">' + '<span style="background: red; padding: 2px 4px; border-radius: 2px;">ERROR</span>' + '<span style="top: 2px; margin-left: 5px; position: relative;">🚨</span>' + '<div style="font-size: 18px; font-weight: bold; margin-top: 20px;">' + message.innerHTML + '</div>' + '<pre>' + stackTrace.innerHTML + '</pre>' + '</div>';
+  return overlay;
+}
+
+function getParents(bundle, id) {
+  var modules = bundle.modules;
+
+  if (!modules) {
+    return [];
+  }
+
+  var parents = [];
+  var k, d, dep;
+
+  for (k in modules) {
+    for (d in modules[k][1]) {
+      dep = modules[k][1][d];
+
+      if (dep === id || Array.isArray(dep) && dep[dep.length - 1] === id) {
+        parents.push(k);
+      }
+    }
+  }
+
+  if (bundle.parent) {
+    parents = parents.concat(getParents(bundle.parent, id));
+  }
+
+  return parents;
+}
+
+function hmrApply(bundle, asset) {
+  var modules = bundle.modules;
+
+  if (!modules) {
+    return;
+  }
+
+  if (modules[asset.id] || !bundle.parent) {
+    var fn = new Function('require', 'module', 'exports', asset.generated.js);
+    asset.isNew = !modules[asset.id];
+    modules[asset.id] = [fn, asset.deps];
+  } else if (bundle.parent) {
+    hmrApply(bundle.parent, asset);
+  }
+}
+
+function hmrAcceptCheck(bundle, id) {
+  var modules = bundle.modules;
+
+  if (!modules) {
+    return;
+  }
+
+  if (!modules[id] && bundle.parent) {
+    return hmrAcceptCheck(bundle.parent, id);
+  }
+
+  if (checkedAssets[id]) {
+    return;
+  }
+
+  checkedAssets[id] = true;
+  var cached = bundle.cache[id];
+  assetsToAccept.push([bundle, id]);
+
+  if (cached && cached.hot && cached.hot._acceptCallbacks.length) {
+    return true;
+  }
+
+  return getParents(global.parcelRequire, id).some(function (id) {
+    return hmrAcceptCheck(global.parcelRequire, id);
+  });
+}
+
+function hmrAcceptRun(bundle, id) {
+  var cached = bundle.cache[id];
+  bundle.hotData = {};
+
+  if (cached) {
+    cached.hot.data = bundle.hotData;
+  }
+
+  if (cached && cached.hot && cached.hot._disposeCallbacks.length) {
+    cached.hot._disposeCallbacks.forEach(function (cb) {
+      cb(bundle.hotData);
+    });
+  }
+
+  delete bundle.cache[id];
+  bundle(id);
+  cached = bundle.cache[id];
+
+  if (cached && cached.hot && cached.hot._acceptCallbacks.length) {
+    cached.hot._acceptCallbacks.forEach(function (cb) {
+      cb();
+    });
+
+    return true;
+  }
+}
+},{}]},{},["../node_modules/parcel-bundler/src/builtins/hmr-runtime.js","critical.js"], null)</script>
+<script src='./assets/packed/app.js?t=20230630061434'></script>
+
+
+
+</body>
+</html>


### PR DESCRIPTION
This adds the prerendered html for a Codemagic YAML cheatsheet created using the tooling from https://github.com/codemagic-ci-cd/codemagic-yaml-cheatsheet with extraneous html removed and links to it from the existing docs YAML getting started page.

![yaml-small](https://github.com/codemagic-ci-cd/codemagic-docs/assets/71999/ceb14bf5-ee4c-4c76-afc5-a959fa2bcdd7)
