### PR TITLE
Update static-code-analysis.md for WFE on how to retrieve test results as a text file

### DIFF
--- a/content/flutter-testing/static-code-analysis.md
+++ b/content/flutter-testing/static-code-analysis.md
@@ -9,9 +9,16 @@ aliases: /testing/static-code-analysis
 
 Test your code with `flutter analyze` to find possible mistakes. You can read more about this feature in [Dart documentation](https://dart.dev/guides/language/analysis-options). By default, Flutter Analyze is disabled and has to be enabled in **App settings > Tests > Static code analysis** by checking the **Enable Flutter analyzer** option.
 
-To run `flutter analyze`, Codemagic specifies the `analyze` command in the **Flutter analyze arguments** field. You can pass additional arguments to customize static code analysis. For example, adding `--write=analyzer-output.txt` prints the results of static code analysis into a text file.
+When enabled, `flutter analyze` will be run with each build. You can see the results and the logs of the analysis under the **Testing** step in build overview.
 
-When enabled, `flutter analyze` will be run with each build. You can see the results and the logs of the analysis under the **Running tests** step in build overview.
+Codemagic specifies the `analyze` command in the **Flutter analyze arguments** field. You can pass additional arguments to customize static code analysis. 
+
+For example, adding `--write=analyzer-output.txt` prints the results of static code analysis into a text file. If this is applied, the generated text file containing the test results can be retrieved as a downloadable artifact by adding this **Pre-publish** script:
+
+```
+cp -r $CM_BUILD_DIR/analyzer-output.txt $CM_EXPORT_DIR/analyzer-output.txt
+```
+
 
 ### Stop build if tests or analysis fail
 


### PR DESCRIPTION
Changed the order and wording of the docs to be a bit clearer. Added a script to retrieve an optional test result text file.