### PR TITLE
specifying to use Other option

### DIFF
--- a/content/knowledge-git/access-private-git-submodules.md
+++ b/content/knowledge-git/access-private-git-submodules.md
@@ -9,9 +9,13 @@ aliases:
 
 If your project requires accessing any private Git submodules or dependencies, you'll need to grant Codemagic access to them in order to build successfully.
 
-1. [Create an SSH key pair](../knowledge-git/generating-an-ssh-key) for use with Codemagic. Note that the SSH key **cannot** be password-protected.
-2. Add the **public key** to your account settings. See how to do that on [GitHub](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account), [Bitbucket](https://confluence.atlassian.com/bitbucket/use-access-keys-294486051.html), [GitLab](https://docs.gitlab.com/ee/ssh/README.html#adding-an-ssh-key-to-your-gitlab-account).
-3.  Copy the contents of the **private key** file add it as an environment variable in the Codemagic UI and import it into your **codemagic.yaml** configuration file.
+1. Add an application to the Codemagic platform.
+2. Select a team or personal account in which you have owner permissions.
+3. Connect the repository using the **Other** option.
+4. Clone a repository from a URL using the SSH method.
+5. [Create an SSH key pair](../knowledge-git/generating-an-ssh-key) for use with Codemagic. Note that the SSH key **cannot** be password-protected.
+6. Add the **public key** to your account settings. See how to do that on [GitHub](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account), [Bitbucket](https://confluence.atlassian.com/bitbucket/use-access-keys-294486051.html), [GitLab](https://docs.gitlab.com/ee/ssh/README.html#adding-an-ssh-key-to-your-gitlab-account).
+7.  Copy the contents of the **private key** file add it as an environment variable in the Codemagic UI and import it into your **codemagic.yaml** configuration file.
 {{<notebox>}}
 **Note:** Make sure the environment variable name ends in `_SSH_KEY`.
 {{</notebox>}}


### PR DESCRIPTION
A lot of customers seem to be confused on how to add a repo with git submodules, and they are not familiar that they need to use the "Other" option

