### PR TITLE
remove reappeared mac minis

### DIFF
--- a/content/partials/specs/versions-macos-intel-xcode-12-5.md
+++ b/content/partials/specs/versions-macos-intel-xcode-12-5.md
@@ -10,7 +10,6 @@ weight: 6
 
 ## Hardware
 
-- Standard VM on Mac mini `2.3GHz Quad Core / 8GB`
 - Premium VM on Mac Pro `3.7GHz Quad Core / 32GB`
 
 ## System

--- a/content/partials/specs/versions-macos-intel-xcode-13-0.md
+++ b/content/partials/specs/versions-macos-intel-xcode-13-0.md
@@ -13,7 +13,6 @@ weight: 7
 
 ## Hardware
 
-- Standard VM on Mac mini `2.3GHz Quad Core / 8GB`
 - Premium VM on Mac Pro `3.7GHz Quad Core / 32GB`
 
 ## System

--- a/content/partials/specs/versions-macos-intel-xcode-13-3.md
+++ b/content/partials/specs/versions-macos-intel-xcode-13-3.md
@@ -10,7 +10,6 @@ weight: 8
 
 ## Hardware
 
-- Standard VM on Mac mini `2.3GHz Quad Core / 8GB`
 - Premium VM on Mac Pro `3.7GHz Quad Core / 32GB`
 
 ## System

--- a/content/partials/specs/versions-macos-intel-xcode-14-2.md
+++ b/content/partials/specs/versions-macos-intel-xcode-14-2.md
@@ -8,7 +8,6 @@ weight: 9
 
 ## Hardware
 
-- Standard VM on Mac mini `2.3GHz Quad Core / 8GB`
 - Premium VM on Mac Pro `3.7GHz Quad Core / 32GB`
 
 ## System


### PR DESCRIPTION
these were accidentally added back to the specs due to automation scripts