### PR TITLE
Update yaml-getting-started.md

### DIFF
--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -175,15 +175,15 @@ The main sections in each workflow are described below.
 `instance_type:` specifies the [build machine type](../specs/machine-type) to use for the build. The supported build machines are:
 | **Instance Type** | **Build Machine** |
 | ------------- | -----------------  |
-| `mac_mini_m1`    | macOS M1 standard VM (default) |
-| `mac_pro`     | macOS Intel VM            |
-| `linux`       | Linux standard VM           |
-| `linux_x2`    | Linux premium VM            |
-| `windows_x2`  | Windows premium VM          |
+| `mac_mini_m1`    | macOS M1  VM (default)   |
+| `mac_mini_m2`    | macOS M2  VM             |
+| `mac_pro`     | macOS Intel VM              |
+| `linux`       | Linux         VM            |
+| `windows_x2`  | Windows         VM          |
 
 <br>
 {{<notebox>}}
-**Note:** The `mac_pro`, `linux`, `linux_x2` and `windows_x2` are only available for teams and users with [billing enabled](../billing/billing/).
+**Note:** The `mac_pro`, `linux` and `windows_x2` are only available for teams and users with [billing enabled](../billing/billing/). `mac_mini_m2` is only available on fixed price annual plan. 
 {{</notebox>}}
 
 ### Environment

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -183,7 +183,7 @@ The main sections in each workflow are described below.
 
 <br>
 {{<notebox>}}
-**Note:** The `mac_pro`, `linux` and `windows_x2` are only available for teams and users with [billing enabled](../billing/billing/). `mac_mini_m2` is only available on fixed price annual plan. 
+**Note:** The `mac_pro`, `linux_x2` and `windows_x2` are only available for teams and users with [billing enabled](../billing/billing/). `mac_mini_m2` is only available on fixed price annual plan. 
 {{</notebox>}}
 
 ### Environment

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -175,11 +175,11 @@ The main sections in each workflow are described below.
 `instance_type:` specifies the [build machine type](../specs/machine-type) to use for the build. The supported build machines are:
 | **Instance Type** | **Build Machine** |
 | ------------- | -----------------  |
-| `mac_mini_m1`    | macOS M1  VM (default)   |
-| `mac_mini_m2`    | macOS M2  VM             |
-| `mac_pro`     | macOS Intel VM              |
-| `linux`       | Linux         VM            |
-| `windows_x2`  | Windows         VM          |
+| `mac_mini_m1`    | Apple silicon M1 Mac mini |
+| `mac_mini_m2`    | Apple silicon M2 Mac mini |
+| `mac_pro` | Intel-based Mac Pro |
+| `linux_x2`  | Linux |
+| `windows_x2`  | Windows |
 
 <br>
 {{<notebox>}}


### PR DESCRIPTION
1. we stopped describing instance types as standard and premium 
2. we don't have linux and linux_x2 instance type anymore. Both use the larger Linux instance so cleaning this up and referring to linux_x2 just as linux
3. adding mac_mini_m2 as instance type