### PR TITLE
Add Legacy Flag to Private Key Export

### DIFF
--- a/content/partials/code-signing-ios-obtain-certificate.md
+++ b/content/partials/code-signing-ios-obtain-certificate.md
@@ -36,7 +36,7 @@ This new private key will be used to create a new iOS Distribution certificate i
 7. Use the following `openssl` command to export the private key:
 
 {{< highlight Shell "style=rrt">}}
-openssl pkcs12 -in IOS_DISTRIBUTION.p12 -nodes -nocerts | openssl rsa -out ios_distribution_private_key
+openssl pkcs12 -in IOS_DISTRIBUTION.p12 -nodes -nocerts --legacy | openssl rsa -out ios_distribution_private_key
 {{< /highlight >}}
 
 8. When prompted for the import password, just press enter. The private key will be written to a file called **ios_distribution_private_key** in the directory where you ran the command.


### PR DESCRIPTION
When the command `openssl pkcs12 -in IOS_DISTRIBUTION.p12 -nodes -nocerts | openssl rsa -out ios_distribution_private_key` is used to extract the private key it comes to the following Error.

```
Error outputting keys and certificates
C0DE35E001000000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:341:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
Could not read private key from <stdin>
```

As stated in [Issue 5059](https://github.com/Kong/insomnia/issues/5059), you can add the legacy Flag to fix this.