### PR TITLE
Update commands to list and create certificates

### DIFF
--- a/content/partials/code-signing-macos.md
+++ b/content/partials/code-signing-macos.md
@@ -166,8 +166,8 @@ To code sign the app, add the following commands in the [`scripts`](../getting-s
             --create
       - name: Fetch Mac Installer Distribution certificates
         script: |  
-            app-store-connect list-certificates --type MAC_APP_DISTRIBUTION --save || \
-            app-store-connect create-certificate --type MAC_APP_DISTRIBUTION --save
+            app-store-connect certificates list --type MAC_APP_DISTRIBUTION --save || \
+            app-store-connect certificates create --type MAC_APP_DISTRIBUTION --save
       - name: Set up signing certificate
         script: keychain add-certificates
       - name: Set up code signing settings on Xcode project

--- a/content/partials/quickstart/code-signing-macos.md
+++ b/content/partials/quickstart/code-signing-macos.md
@@ -114,8 +114,8 @@ To code sign the app, add the following commands in the [`scripts`](../getting-s
             --create
       - name: Fetch Mac Installer Distribution certificates
         script: |  
-            app-store-connect list-certificates --type MAC_APP_DISTRIBUTION --save || \
-            app-store-connect create-certificate --type MAC_APP_DISTRIBUTION --save
+            app-store-connect certificates list --type MAC_APP_DISTRIBUTION --save || \
+            app-store-connect certificates create --type MAC_APP_DISTRIBUTION --save
       - name: Set up signing certificate
         script: keychain add-certificates
       - name: Set up code signing settings on Xcode project

--- a/content/yaml-quick-start/building-a-flutter-app.md
+++ b/content/yaml-quick-start/building-a-flutter-app.md
@@ -583,8 +583,8 @@ workflows:
         script: | 
            # You may omit the first command if you already have
            # the installer certificate and provided the corresponding private key
-            app-store-connect list-certificates --type MAC_INSTALLER_DISTRIBUTION --save || \
-            app-store-connect create-certificate --type MAC_INSTALLER_DISTRIBUTION --save
+            app-store-connect certificates list --type MAC_INSTALLER_DISTRIBUTION --save || \
+            app-store-connect certificates create --type MAC_INSTALLER_DISTRIBUTION --save
             
       - name: Set up signing certificate
         script: keychain add-certificates

--- a/content/yaml-quick-start/building-a-unity-app.md
+++ b/content/yaml-quick-start/building-a-unity-app.md
@@ -600,8 +600,8 @@ In this step you can also define the build artifacts you are interested in. Thes
           --create
     - name: Fetch Mac Installer Distribution certificates
       script: | 
-        app-store-connect list-certificates --type MAC_INSTALLER_DISTRIBUTION --save || \
-        app-store-connect create-certificate --type MAC_INSTALLER_DISTRIBUTION --save 
+        app-store-connect certificates list --type MAC_INSTALLER_DISTRIBUTION --save || \
+        app-store-connect certificates create --type MAC_INSTALLER_DISTRIBUTION --save 
     - name: Add certs to keychain
       script: | 
         keychain add-certificates
@@ -979,8 +979,8 @@ workflows:
             --create
       - name: Fetch Mac Installer Distribution certificates
         script: |  
-            app-store-connect list-certificates --type MAC_APP_DISTRIBUTION --save || \
-            app-store-connect create-certificate --type MAC_APP_DISTRIBUTION --save
+            app-store-connect certificates list --type MAC_APP_DISTRIBUTION --save || \
+            app-store-connect certificates create --type MAC_APP_DISTRIBUTION --save
       - name: Add certs to keychain
         script: | 
           keychain add-certificates


### PR DESCRIPTION
Some Codemagic CLI tools were renamed in https://github.com/codemagic-ci-cd/cli-tools/pull/386. This PR ensures that deprecated names are not referenced in current docs. 