### PR TITLE
Support the new FVM config file

### DIFF
--- a/content/yaml-quick-start/building-a-flutter-app.md
+++ b/content/yaml-quick-start/building-a-flutter-app.md
@@ -56,7 +56,7 @@ workflows:
             flutter: fvm
 {{< /highlight >}}
 {{<notebox>}}
-**Note**: This automatically sets the Flutter version from your project's `fvm_config.json` file, located at the root of your project in the `.fvm` directory. If this file does not exist, the build will fail.
+**Note**: This automatically sets the Flutter version from your project's `.fvmrc` file (or from `.fvm/fvm_config.json` if you're using an older version of FVM). If this file does not exist, the build will fail.
 {{</notebox>}}
 
 Moreover, when using FVM, Codemagic allows you to set the specific FVM flavor in your `codemagic.yaml` to provide all the needed flexibility when managing the Flutter version.


### PR DESCRIPTION
Starting from [FVM v3.0.0](https://github.com/leoafarias/fvm/releases/tag/3.0.0) the configuration file which it used to be at `.fvm/fvm_config.json` got moved to `.fvmrc` and the flutter version key has changed as well from 
`{ "flutterSdkVersion": "..", "flavors": { ... }}` 
to 
`{ "flutter": "..", "flavors": { ... }}`.