### PR TITLE
Update "Creating an App Store API key for Codemagic" sections

### DIFF
--- a/content/flutter-code-signing/ios-code-signing.md
+++ b/content/flutter-code-signing/ios-code-signing.md
@@ -52,17 +52,7 @@ The following sections describe how to set up automatic code signing for builds 
 
 ### Step 1. Creating an App Store API key for Codemagic
 
-Only App Store Connect admin can create an API key. It is recommended to create a dedicated App Store Connect API key for Codemagic in [App Store Connect](https://appstoreconnect.apple.com/access/api). To do so:
-
-1. Log in to App Store Connect and navigate to **Users and Access > Keys**.
-2. Click on the + sign to generate a new API key.
-3. Enter the name for the key and select an access level. We recommend choosing `App Manager`, considering that `Developer` does not have the required permissions to upload to the store. Read more about Apple Developer Program role permissions [here](https://help.apple.com/app-store-connect/#/deve5f9a89d7).
-4. Click **Generate**.
-5. As soon as the key is generated, you can see it added to the list of active keys. Click **Download API Key** to save the private key for later. Note that the key can only be downloaded once.
-
-{{<notebox >}} 
-**Note:** Take note of the **Issuer ID** above the table of active keys as well as the **Key ID** of the generated key as these will be required when setting up the Apple Developer Portal integration in Codemagic UI.
-{{</notebox>}}
+{{< include "/partials/app-store-connect-api-key.md">}}
 
 ### Step 2. Connecting the Apple Developer Portal integration for your team/account
 

--- a/content/flutter-code-signing/macos-code-signing.md
+++ b/content/flutter-code-signing/macos-code-signing.md
@@ -50,17 +50,7 @@ You may revoke an existing certificate to allow Codemagic to create a new one us
 
 ### Step 1. Creating an App Store API key for Codemagic
 
-It is recommended to create a dedicated App Store Connect API key for Codemagic in [App Store Connect](https://appstoreconnect.apple.com/access/api). To do so:
-
-1. Log in to App Store Connect and navigate to **Users and Access > Keys**.
-2. Click on the + sign to generate a new API key.
-3. Enter the name for the key and select an access level. We recommend choosing either `Developer` or `App Manager`, read more about Apple Developer Program role permissions [here](https://help.apple.com/app-store-connect/#/deve5f9a89d7).
-4. Click **Generate**.
-5. As soon as the key is generated, you can see it added to the list of active keys. Click **Download API Key** to save the private key for later. Note that the key can only be downloaded once.
-
-{{<notebox >}}
-**Note:** Take note of the **Issuer ID** above the table of active keys as well as the **Key ID** of the generated key as these will be required when setting up the Apple Developer Portal integration in Codemagic UI.
-{{</notebox>}}
+{{< include "/partials/app-store-connect-api-key.md">}}
 
 ### Step 2. Connecting the Apple Developer Portal integration for your team/account
 

--- a/content/flutter-publishing/publishing-to-app-store.md
+++ b/content/flutter-publishing/publishing-to-app-store.md
@@ -35,17 +35,7 @@ This section gives step-by-step instructions on how to configure publishing to A
 **Tip:** You may also reuse any of the keys you've already set up for automatic [iOS](../code-signing/ios-code-signing/#automatic-code-signing) or [macOS](../code-signing/macos-code-signing/#automatic-code-signing) code signing.
 {{</notebox>}}
 
-It is recommended to create a dedicated App Store Connect API key for Codemagic in [App Store Connect](https://appstoreconnect.apple.com/access/api). To do so:
-
-1. Log in to App Store Connect and navigate to **Users and Access > Keys**.
-2. Click on the + sign to generate a new API key.
-3. Enter the name for the key and select an access level. For App Store Connect publishing, the key needs to have `App Manager` permissions. Read more about Apple Developer Program role permissions [here](https://help.apple.com/app-store-connect/#/deve5f9a89d7).
-4. Click **Generate**.
-5. As soon as the key is generated, you can see it added to the active keys list. Click **Download API Key** to save the private key for later. Note that the key can only be downloaded once.
-
-{{<notebox >}} 
-**Note:** Take note of the **Issuer ID** above the table of active keys and the **Key ID** of the generated key as these will be required when setting up the Apple Developer Portal integration in Codemagic UI.
-{{</notebox>}}
+{{< include "/partials/app-store-connect-api-key.md">}}
 
 ### Step 2. Connecting the Apple Developer Portal integration for your team/account
 


### PR DESCRIPTION
This PR updates outdated "Creating an App Store API key for Codemagic" sections to use `partials/app-store-connect-api-key.md`. This was updated in https://github.com/codemagic-ci-cd/codemagic-docs/pull/2373

![Screenshot 2024-02-22 at 22 14 07](https://github.com/codemagic-ci-cd/codemagic-docs/assets/48603081/893a8025-afdf-4215-a9f2-e706f7d817a7)
