### PR TITLE
Triggering build on pull_request update

### DIFF
--- a/content/yaml-running-builds/starting-builds-automatically.md
+++ b/content/yaml-running-builds/starting-builds-automatically.md
@@ -104,7 +104,7 @@ triggering:
       source: false  
 {{< /highlight >}}
 
-**Example 2**. Setting `source:true`, `pattern:main` and triggering events `pull_request` and `push` which will trigger the build on the `main` branch once the pull request has been merged from the `feature` branch into the `main` branch.
+**Example 2**. Setting `source:true`, `pattern:main` will trigger the build on the `main` branch once the pull request has been merged from the `feature` branch into the `main` branch.
 
 {{< highlight yaml "style=paraiso-dark">}}
 triggering:

--- a/content/yaml-running-builds/starting-builds-automatically.md
+++ b/content/yaml-running-builds/starting-builds-automatically.md
@@ -104,11 +104,12 @@ triggering:
       source: false  
 {{< /highlight >}}
 
-**Example 2**. Setting `source:true` and `branch:main`, will trigger the build on the `main` branch once the pull request has been merged from the `feature` branch into the `main` branch.
+**Example 2**. Setting `source:true`, `branch:main` and triggering events `push` and `pull_request` will trigger the build on the `main` branch once the pull request has been merged from the `feature` branch into the `main` branch.
 
 {{< highlight yaml "style=paraiso-dark">}}
 triggering:
   events:
+    - push
     - pull_request
   branch_patterns:
     - pattern: 'main'

--- a/content/yaml-running-builds/starting-builds-automatically.md
+++ b/content/yaml-running-builds/starting-builds-automatically.md
@@ -104,7 +104,7 @@ triggering:
       source: false  
 {{< /highlight >}}
 
-**Example 2**. Setting `source:true`, `branch:main` and triggering events `push` and `pull_request` will trigger the build on the `main` branch once the pull request has been merged from the `feature` branch into the `main` branch.
+**Example 2**. Setting `source:true`, `pattern:main` and triggering events `pull_request` and `push` which will trigger the build on the `main` branch once the pull request has been merged from the `feature` branch into the `main` branch.
 
 {{< highlight yaml "style=paraiso-dark">}}
 triggering:


### PR DESCRIPTION
There is an example [in the docs](https://docs.codemagic.io/yaml-running-builds/starting-builds-automatically/#:~:text=Example%202.%20Setting%20source%3Atrue%20and%20branch%3Amain%2C%20will%20trigger%20the%20build%20on%20the%20main%20branch%20once%20the%20pull%20request%20has%20been%20merged%20from%20the%20feature%20branch%20into%20the%20main%20branch.) that is showing how to trigger a build on the main branch when a feature branch is merged into it, but in order to this be valid, it needs to have the push event as well