### PR TITLE
added github checks and build dashboards page to WFE Various section

### DIFF
--- a/content/knowledge-others/build-dashboards.md
+++ b/content/knowledge-others/build-dashboards.md
@@ -1,0 +1,44 @@
+---
+title: Build dashboards
+description: Use Build dashboards for sharing builds
+weight: 3
+aliases: 
+  - /knowledge-base/shared-dashboards
+  - /knowledge-base/public-dashboards
+---
+
+Build dashboards make it possible for teams to share the list of team's builds, release notes (if passed) and build artifacts with people outside Codemagic using a public link (build logs will not be exposed). This is a convenient option for distributing builds to testers or sharing build artifacts with stakeholders.
+
+The artifact download links in build dashboards are valid for 24 hours. Download links are recreated on each dashboard refresh.
+
+{{<notebox>}}
+**Note:** The build dashboards feature is available for teams only. It is not possible to create build dashboards for apps on personal accounts.
+{{</notebox>}}
+
+## Enabling build dashboards
+
+To use build dashboards, team admins will have to enable the feature in team settings. 
+
+In team settings, expand the **Build dashboards** section and click **Enable sharing**. This will allow any team member to create dashboards and generate public links to share them.
+
+Build dashboards can be disabled anytime by clicking **Disable sharing**.
+
+## Creating and sharing a build dashboard
+
+1. Open the **Builds** page via the left navigation bar.
+2. Click the **Filters** button at the top right of the page and use the **team**, **application**, **workflow**, **branch**, **tag** and **status** filters to create a build dashboard.
+3. Then click **Share dashboard** at the top of the page to generate a public link. A popup with the generated link will appear, and you can copy the link to the clipboard. The generated link will be also saved to the **Build dashboards** section in team settings.
+
+{{<notebox>}}
+**Note:** **Share dashboard** will be available only when a team with build dashboards enabled is selected in the **Builds** page. 
+{{</notebox>}}
+
+{{<notebox>}}
+**Note:** Please note that anyone with the public link can access the build dashboard and download build artifacts.
+{{</notebox>}}
+
+## Managing links
+
+All generated links to build dashboards are listed in the **Build dashboards** section in team settings.
+
+Links can be revoked by deleting them or when a team admin disables sharing by clicking **Disable sharing**. When sharing is re-enabled, the available links become active again.

--- a/content/knowledge-others/github-checks.md
+++ b/content/knowledge-others/github-checks.md
@@ -1,0 +1,27 @@
+---
+title: GitHub Checks
+description: How to report PR build statuses to GitHub as checks
+weight: 6
+startLineBreak: true
+aliases: 
+  - /building/github-checks
+  - /configuration/github-checks
+---
+
+{{<notebox>}}
+**Note:** Reporting to GitHub Checks is available for repositories connected via [Codemagic GitHub App](https://github.com/apps/codemagic-ci-cd) integration.
+{{</notebox>}}
+
+If you have set up [checks](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-status-checks#checks) in GitHub, your workflow build summary will appear in the Checks tab of the pull request in GitHub. For every build on the branch to be merged, Codemagic will report the build summary along with the status and logs of individual build steps to GitHub. Failed checks will block merging the pull request. In case reporting commit check failed, Codemagic attempts to report commit status.
+
+Checks can be set up in GitHub when configuring [branch protection rules](https://docs.github.com/en/github/administering-a-repository/managing-a-branch-protection-rule) for a repository. 
+
+1. In Github, open the **Settings** of your repository.
+2. In the left menu, click **Branches**.
+3. Click **Add rule** to add a new branch protection rule.
+4. Enter the name of the branch you want to protect in the **Branch name pattern** field. For example, if you want to require checks on pull requests to the master branch, enter `master`.
+5. Under **Protect matching branches**, check **Require status checks to pass before merging**.
+6. Select the name of the workflow to add it as a check. Note that the workflow name is listed only if you have already built this workflow in Codemagic.
+7. Click **Save changes**.
+
+Note that it's not currently possible to rerun failed checks (builds) from GitHub UI.


### PR DESCRIPTION
Some generic docs are available in the left menu only for yaml but not for Flutter Workflow Editor. For example, Build dashboards and GitHub checks.
Added this info on the Various section in WFE
![image](https://github.com/codemagic-ci-cd/codemagic-docs/assets/38918425/e07e98d6-ad8e-475a-bdb4-8efcb81b8eee)

![image](https://github.com/codemagic-ci-cd/codemagic-docs/assets/38918425/fa978384-1308-4fdf-8eb0-d71f7c4dbc5f)
