### PR TITLE
Remove section about getting variable ID

### DIFF
--- a/content/rest-api/applications.md
+++ b/content/rest-api/applications.md
@@ -6,6 +6,11 @@ weight: 2
 
 APIs for managing applications are currently available for developers to preview. During the preview period, the API may change without advance notice.
 
+{{<notebox>}}
+**Using the API with apps configured with codemagic.yaml:**<br>
+Unlike with Workflow Editor, information about workflows in **codemagic.yaml** is not stored in Codemagic and is therefore not available before starting a build and cloning the repository. Therefore, the API does not return workflow information such as `workflowId` for **codemagic.yaml** workflows.
+{{</notebox>}}
+
 ## Retrieve all applications
 
 `GET /apps`
@@ -197,8 +202,6 @@ base64 id_rsa | pbcopy
 Codemagic allows you to fetch and modify application variables and secrets using the REST API. Note that the API works slightly differently depending on whether your application is configured to use the `Workflow Editor` or `YAML configuration`.
 
 For yaml, variables and secrets are manually configured on the **Environment variables** tab in your application settings. These variables and secrets can be accessed in your configuration file across all workflows with the use of [groups](../building/environment-variable-groups). Variables configured for the `Workflow Editor` are specific to one workflow.
-
-Note that the API returns workflow information such as `workflowId` or `workflowName` only for Worfklow Editor workflows. For workflows configured in **codemagic.yaml**, this information is not available without cloning the repository.
 
 ### Fetch variables
 

--- a/content/rest-api/applications.md
+++ b/content/rest-api/applications.md
@@ -6,8 +6,6 @@ weight: 2
 
 APIs for managing applications are currently available for developers to preview. During the preview period, the API may change without advance notice.
 
-{{}} **Note:** Using REST API will not fetch information about workflows when configuring with **codemagic.yaml**. It is because only workflows from the Workflow Editor are defaulted as no accessible data is present from **codemagic.yaml** until a repository is cloned, which means that there is no way to retrieve workflow IDs from **codemagic.yaml** before triggering a build. {{}}
-
 ## Retrieve all applications
 
 `GET /apps`
@@ -199,6 +197,8 @@ base64 id_rsa | pbcopy
 Codemagic allows you to fetch and modify application variables and secrets using the REST API. Note that the API works slightly differently depending on whether your application is configured to use the `Workflow Editor` or `YAML configuration`.
 
 For yaml, variables and secrets are manually configured on the **Environment variables** tab in your application settings. These variables and secrets can be accessed in your configuration file across all workflows with the use of [groups](../building/environment-variable-groups). Variables configured for the `Workflow Editor` are specific to one workflow.
+
+Note that the API returns workflow information such as `workflowId` or `workflowName` only for Worfklow Editor workflows. For workflows configured in **codemagic.yaml**, this information is not available without cloning the repository.
 
 ### Fetch variables
 

--- a/content/rest-api/applications.md
+++ b/content/rest-api/applications.md
@@ -327,32 +327,6 @@ To add binary-based files (e.g. images), they need to be [`base64 encoded`](../v
 {{< /highlight >}}
 
 
-### Getting variable_id
-
-#### Example
-
-{{< highlight bash "style=paraiso-dark">}}
-  curl -XGET \
-       -H "X-Auth-Token: $CM_API_KEY" \
-       -H "Content-type: application/json" \
-       "https://api.codemagic.io/apps/YOUR_APP_ID/variables"
-{{< /highlight >}}
-
-
-#### Response
-
-{{< highlight json "style=paraiso-dark">}}
-  [{
-    "group": "test",
-    "id": "0000000000000",
-    "key": "TEST",
-    "secure": true,
-    "value": "[HIDDEN]"
-  }]
-{{< /highlight >}}
-
-
-
 ### Update existing variable
 
 `POST /apps/:id/variables/:variable_id`


### PR DESCRIPTION
A separate section about getting the variable ID in Applications API is unnecessary as it duplicates the "Fetch variables" section. 

Fixed the formatting and rephrased the note about workflow information for codemagic.yaml workflows. 