### PR TITLE
Document releasing App Store version in phases

### DIFF
--- a/content/partials/quickstart/publishing-app-store.md
+++ b/content/partials/quickstart/publishing-app-store.md
@@ -62,4 +62,12 @@ publishing:
     # Optional. The name of the person or entity that owns the exclusive rights
     # to your app, preceded by the year the rights were obtained.
     copyright: 2021 Nevercode Ltd
+  
+    # Optional boolean. Whether or not to release an App Store version update in phases.
+    # With this option turned on, your version update will be released over a 7-day period
+    # to a percentage of your users (selected at random by their Apple ID) with automatic
+    # updates turned on. Learn more from 
+    # https://developer.apple.com/help/app-store-connect/update-your-app/release-a-version-update-in-phases.
+    # If not specified, then App Store version default phased release configuration is reused.
+    phased_release: true
 {{< /highlight >}}

--- a/content/partials/yaml-publishing-app-store-connect-environment-variables.md
+++ b/content/partials/yaml-publishing-app-store-connect-environment-variables.md
@@ -65,6 +65,14 @@ publishing:
     # Optional. The name of the person or entity that owns the exclusive rights
     # to your app, preceded by the year the rights were obtained.
     copyright: 2021 Nevercode Ltd
+
+    # Optional boolean. Whether or not to release an App Store version update in phases.
+    # With this option turned on, your version update will be released over a 7-day period
+    # to a percentage of your users (selected at random by their Apple ID) with automatic
+    # updates turned on. Learn more from 
+    # https://developer.apple.com/help/app-store-connect/update-your-app/release-a-version-update-in-phases.
+    # If not specified, then App Store version default phased release configuration is reused.
+    phased_release: true
 {{< /highlight >}}
 
 {{<notebox>}}

--- a/content/partials/yaml-publishing-app-store-connect-team-integration.md
+++ b/content/partials/yaml-publishing-app-store-connect-team-integration.md
@@ -70,6 +70,14 @@ workflows:
         # Optional. The name of the person or entity that owns the exclusive rights
         # to your app, preceded by the year the rights were obtained.
         copyright: 2021 Nevercode Ltd
+
+        # Optional boolean. Whether or not to release an App Store version update in phases.
+        # With this option turned on, your version update will be released over a 7-day period
+        # to a percentage of your users (selected at random by their Apple ID) with automatic
+        # updates turned on. Learn more from 
+        # https://developer.apple.com/help/app-store-connect/update-your-app/release-a-version-update-in-phases.
+        # If not specified, then App Store version default phased release configuration is reused.
+        phased_release: true
 {{< /highlight >}}
 
 {{<notebox>}}


### PR DESCRIPTION
**Background**

Version [0.51.0](https://github.com/codemagic-ci-cd/cli-tools/releases/tag/v0.51.0) of Codemagic CLI tools added support for [releasing App Store versions in phases](https://developer.apple.com/help/app-store-connect/update-your-app/release-a-version-update-in-phases) and this feature is also supported by Codemagic YAML workflows.

**What was done**

Update YAML App Store publishing docs with information about releasing App Store version in phases: include `publishing -> app_store_connect -> phased_release` key with description in YAML workflow snippets where App Store Connect publishing with App Store submission is enabled.