### PR TITLE
Add documentation entry for start build inputs

### DIFF
--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -107,7 +107,7 @@ workflows:
 
 As no `default` value is provided in the above example, then name must be specified when starting builds for this workflow, or otherwise it will be left blank.
 
-### Using inputs to conditionally run scripts (booleans)
+### Using inputs to conditionally run scripts
 
  Boolean inputs can be useful to control whether some build steps are enabled or disabled, or they can be used to turn some features on or off. When given boolean values are substituted into the workflow, then their type is kept as boolean as long as they are not directly used within other values that are already strings (such as scripts). 
 
@@ -159,7 +159,7 @@ echo: "My boolean: true"
 if build is started with `myTruthValue: true`.
 {{</notebox>}}
 
-### Using inputs for publishing (number)
+### Using inputs for publishing
 
 You can use number inputs for build versioning or to control other release parameters, such as rollout fraction or in-app update priority. As with booleans, number types are also persisted when substitutions are being made to workflows unless the value is not directly used within a string. Both integers and floating point numbers are accepted as valid values.
 
@@ -192,7 +192,7 @@ workflows:
           rollout_fraction: ${{ inputs.rolloutFraction }}
 {{< /highlight >}}
 
-### Using inputs for determining build distribution type (choice)
+### Using inputs for determining build distribution type
 
 Inputs with type `choice` provide a way to limit the user to choose only specific predefined values for inputs, such as distribution type.
 

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -10,9 +10,7 @@ Build inputs are customizable parameters you can define within your workflow to 
 
 Inputs are workflow-specific and are defined in `codemagic.yaml` under the `inputs` mapping (see the [example](#minimal-example) below). The started workflow receives specified input values in the `inputs` context, i.e. `${{ inputs.inputId }}` is replaced with the value passed to input with identifier `inputId`.
 
-When starting a build for a workflow that has inputs, Codemagic will show a form where user can enter desired values before starting the build.
-
-#### Minimal example
+### Minimal example
 
 {{< highlight yaml "style=paraiso-dark">}}
 workflows:
@@ -25,6 +23,26 @@ workflows:
     scripts:
       - echo "Hello, ${{ inputs.name }}"
 {{< /highlight >}}
+
+## Starting Builds with Inputs
+
+To successfully start a build, all required inputs must be specified. For optional inputs (those with required: false), the provided default value will be used if no value is specified when the build is started.
+
+{{<notebox>}}
+**Note**: Builds will fail if invalid values are provided for inputs (strings for numbers inputs, undefined choice options, etc.) or values are missing for required inputs.
+{{</notebox>}}
+
+### Starting Builds Manually via Codemagic UI
+
+When starting a build via the Codemagic UI, you will automatically be prompted to enter the inputs. Optional inputs are pre-filled with default values, but all required inputs must be manually entered before the build can be started.
+
+### Starting Builds Using REST API
+
+To start a build using the REST API, values for all required inputs must be included in the `POST` request payload. For more detailed information on starting builds with inputs using the REST API, refer to the section [below](#specify-inputs-when-starting-builds-with-api). Optional inputs can be omitted from the request payload; their default values will be used instead.
+
+### Starting Builds Using Webhook Events
+
+Only builds that do not rely on required inputs can be started with webhook events. If you want to use Git events to automatically trigger builds for workflows with inputs, ensure that all inputs for those workflows have default values.
 
 ## YAML schema for inputs
 

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -35,13 +35,17 @@ All inputs must be specified to successfully start a build, either by providing 
 
 ### Starting builds manually via Codemagic UI
 
-When starting a build via the Codemagic UI, you will automatically be prompted to enter the inputs. Inputs that have predefined default values will be pre-filled with those values from configuration file. All other inputs must be manually entered before the build can be started.
+When starting a build via the Codemagic UI, you will automatically be prompted to enter the inputs. Inputs that have predefined default values will be prefilled with those values from configuration file. All other inputs must be manually entered before the build can be started.
 
-Not entering anything for a string input will result in an empty string, i.e. `""`. For other input types an actual value which matches the requested type must be entered. 
+{{<notebox>}}
+**Note on inputs without default values:**
+
+Not entering anything for a string input will result in an empty string, i.e. `""`. Boolean inputs default to `false` in the UI. For other input types, an actual value that matches the requested type must be entered.
+{{</notebox>}}
 
 ### Starting builds using webhook events
 
-Only builds that do not rely on inputs can be started with webhook events. If you want to use Git events or scheduled builds to automatically trigger builds for workflows with inputs, ensure that all inputs for those workflows have default values.
+Only workflows that do not require user input for values can be started with webhook events. If you want to use Git events or scheduled builds to automatically trigger builds for workflows with inputs, ensure that all inputs in those workflows have default values. Otherwise, the build will fail due to undefined inputs.
 
 ## YAML schema for inputs
 

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -91,7 +91,7 @@ Provide a default value for the input parameter. If type is `choice`, then it mu
 
 Below are some example use cases for leveraging different types of build inputs in your workflows.
 
-### Pass input values to script commands (strings)
+### Using input values in scripts
 
 You can use inputs in scripts by referencing the ID of the input.
 
@@ -133,7 +133,6 @@ workflows:
           condition: ${{ inputs.runTests }}
       - ./setup_code_signing.sh
       - xcode-project build-ipa --project "project.xcodeproj" --scheme "app"
-      - echo "Hello, ${{ inputs.name }}"
     artifacts:
       - build/**/*.ipa
     publishing:

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -29,10 +29,6 @@ workflows:
 
 All inputs must be specified to successfully start a build, either by providing a `default` value in the YAML configuration, or giving a one-off value when starting the build. 
 
-{{<notebox>}}
-**Note**: Builds will fail if invalid values are provided (strings for number inputs, undefined choice options, etc.) or values are missing.
-{{</notebox>}}
-
 ### Starting builds manually via Codemagic UI
 
 When starting a build via the Codemagic UI, you will automatically be prompted to enter the inputs. Inputs that have predefined default values will be prefilled with those values from configuration file. All other inputs must be manually entered before the build can be started.

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -6,11 +6,9 @@ weight: 6
 
 ## Overview
 
-Build inputs are customizable parameters that you can define within your workflow. These parameters allow users to provide specific values when starting a build for the workflow, making it more flexible and adaptable to different scenarios.
+Build inputs are customizable parameters you can define within your workflow to make it more adaptable to different scenarios. With build inputs, you can create a single workflow and run it with different configurations by providing the values for inputs when starting a build for the workflow. For example, you can use build inputs to determine whether to build the workflow for test or release purposes or which app flavor to build. This eliminates the need to create multiple similar workflows with specific hardcoded values, making the workflow more reusable and dynamic.
 
-By using inputs, you can tailor your workflow's behavior based on user-provided values. This eliminates the need to hardcode specific values within the workflow itself, making it more reusable and dynamic.
-
-Inputs are workflow specific and are defined in `codemagic.yaml` under `inputs` mapping (see the [example](#minimal-example) below). Started workflow receives specified input values in the `inputs` context, i.e. `${{ inputs.inputId }}` is replaced with value passed to input with identifier `inputId`.
+Inputs are workflow-specific and are defined in `codemagic.yaml` under the `inputs` mapping (see the [example](#minimal-example) below). The started workflow receives specified input values in the `inputs` context, i.e. `${{ inputs.inputId }}` is replaced with the value passed to input with identifier `inputId`.
 
 When starting a build for a workflow that has inputs, Codemagic will show a form where user can enter desired values before starting the build.
 
@@ -112,7 +110,7 @@ workflows:
 
 In the above workflow user is prompted with two options when starting a build:
 1. whether to run tests before build, which controls the first script step using `when` condition,
-2. whether to submit the build ipa to TestFlight as part of App Store Connect publishing.
+2. whether to submit the built ipa to TestFlight as part of App Store Connect publishing.
 
 Defaults are provided for both inputs and standard build can be started without choosing anything. 
 

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -1,0 +1,226 @@
+---
+title: Build inputs
+description: Specify optional inputs that are passed to the workflow when starting a build
+weight: 6
+---
+
+## Overview
+
+Build inputs are customizable parameters that you can define within your workflow. These parameters allow users to provide specific values when starting a build for the workflow, making it more flexible and adaptable to different scenarios.
+
+By using inputs, you can tailor your workflow's behavior based on user-provided values. This eliminates the need to hardcode specific values within the workflow itself, making it more reusable and dynamic.
+
+Inputs are workflow specific and are defined in `codemagic.yaml` under `inputs` mapping (see the [example](#minimal-example) below). Started workflow receives specified input values in the `inputs` context, i.e. `${{ inputs.inputId }}` is replaced with value passed to input with identifier `inputId`.
+
+When starting a build for a workflow that has inputs, Codemagic will show a form where user can enter desired values before starting the build.
+
+#### Minimal example
+
+{{< highlight yaml "style=paraiso-dark">}}
+workflows:
+  greetings:
+    inputs:
+      name:
+        description: Who is greeted?
+        required: false
+        default: Codemagic
+    scripts:
+      - echo "Hello, ${{ inputs.name }}"
+{{< /highlight >}}
+
+## YAML schema for inputs
+
+Build inputs are defined in `codemagic.yaml` as a mapping `workflow.<workflow_id>.inputs` where keys are input IDs and values are inputs that have the following fields.
+
+### `required`
+
+A **boolean** value determining whether the input must be specified when starting a build. If `false`, then a default value must be defined. **Must be defined**.
+
+### `description`
+
+A **string** description for this build input. Description is displayed in Codemagic when manually starting a build for this workflow and user is prompted to provide values for the inputs. **Must be defined**.
+
+### `type`
+
+**This must be one of: `boolean`, `choice`, `number` or `string`. By default, `string` is assumed.**
+
+Defines the data type of the input parameter. Input values for the `choice` type are resolved to strings and must be defined in the `options` field. Values for inputs with types `boolean` and `number` are persisted as booleans and integers or floating point numbers respectively, instead of converting them to strings as long as they are not directly used in string interpolations.
+
+### `options`
+
+Provide a list of values as options for the `choice` input. Values are all implicitly cast to strings. **Required if type is `choice` and prohibited otherwise**.
+
+### `default`
+
+Provide a default value for the input parameter. If `type` is choice, then it must be one of the defined `options`, otherwise value type must match with the `type` definition.  **Must be specified if the input is not required and prohibited otherwise**.
+
+## Examples
+
+### String inputs
+
+Default type for inputs is `string`. So, when declaring an input whose values are strings we can omit the `type` field. 
+
+{{< highlight yaml "style=paraiso-dark">}}
+workflows:
+  greetings:
+    inputs:
+      name:
+        description: Who is greeted?
+        required: true
+    scripts:
+      - echo "Hello, ${{ inputs.name }}"
+{{< /highlight >}}
+
+As in the above example input is marked as required, then builds for this workflow can only be started if value is provided for this input.
+
+### Boolean inputs
+
+When given boolean values are substituted into the workflow, then their type is kept as boolean as long as they are not directly used within other values that are already strings (such as scripts). Consequently, boolean inputs can be useful to control whether some build steps are enabled or disabled, or they can be used to turn some features on or off. Such as:
+
+{{< highlight yaml "style=paraiso-dark">}}
+workflows:
+  ios:
+    inputs:
+      submitToTestFlight:
+        description: Enable testflight submission
+        required: false
+        type: boolean
+        default: false
+      runTests:
+        description: Run tests before build
+        required: false
+        type: boolean
+        default: true
+    integrations:
+      app_store_connect: MY_ASC_KEY
+    scripts:
+      - name: Run tests
+        script: xcode-project run-tests --project "project.xcodeproj" --scheme "App"
+        test_report: build/ios/test/*.xml
+        when:
+          condition: ${{ inputs.runTests }}
+      - ./setup_code_signing.sh
+      - xcode-project build-ipa --project "project.xcodeproj" --scheme "app"
+      - echo "Hello, ${{ inputs.name }}"
+    artifacts:
+      - build/**/*.ipa
+    publishing:
+      app_store_connect:
+        auth: integration
+        submit_to_testflight: ${{ inputs.submitToTestFlight }}
+{{< /highlight >}}
+
+In the above workflow user is prompted with two options when starting a build:
+1. whether to run tests before build, which controls the first script step using `when` condition,
+2. whether to submit the build ipa to TestFlight as part of App Store Connect publishing.
+
+Defaults are provided for both inputs and standard build can be started without choosing anything. 
+
+### Choice inputs
+
+Inputs with type choice provide a way to limit the user to choose only specific predefined values for inputs. Choice options are shows to user as a dropdowns. Choices can be useful to prevent typos or other human errors, and to easily present only the values that are relevant to use-case.
+
+Inputs with type `choice` must define additional field `options` where valid choices are listed.
+
+{{< highlight yaml "style=paraiso-dark">}}
+workflows:
+  ios:
+    inputs:
+      distributionType:
+        description: iOS distribution type 
+        required: false
+        type: choice
+        options: ["ad_hoc", "app_store", "development", "invalid"]
+        default: development
+    integrations:
+      app_store_connect: MY_ASC_KEY
+    environment:
+      ios_signing:
+        distribution_type: ${{ inputs.distributionType }}
+        bundle_identifier: com.example.app
+    scripts:
+      - xcode-project use-profiles
+      - flutter build ipa --debug --export-options-plist "${HOME:?}/export_options.plist"
+{{< /highlight >}}
+
+### Number inputs
+
+As with booleans, number types are also persisted when substitutions are being made to workflows unless the value is not directly used within a string. Both integers and floating point numbers are accepted as valid values.
+
+{{< highlight yaml "style=paraiso-dark">}}
+workflows:
+  ios:
+    inputs:
+      googlePlayInAppUpdatePriority:
+        description: Google Play publisher priority
+        required: false
+        type: number
+        default: 4
+      buildNumber:
+        description: Build number for artifact versioning
+        required: true
+        type: number
+      rolloutFraction:
+        description: Rollout fraction for Google Play release promotion
+        required: false
+        type: number
+        default: 0.25
+    environment:
+      groups: 
+        - google_credentials  
+    scripts:
+      - flutter build apk --build-number="${{ inputs.buildNumber }}" --release
+    publishing:
+      google_play:
+        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        in_app_update_priority: ${{ inputs.googlePlayInAppUpdatePriority }}
+        release_promotion:
+          track: alpha
+          rollout_fraction: ${{ inputs.rolloutFraction }}
+{{< /highlight >}}
+
+## Specify inputs when starting builds with API
+
+Builds for workflows which have **required inputs** (i.e. inputs without default values) cannot be started without specifying values for those inputs. This also applies when starting builds using [API](/rest-api/builds/#start-a-new-build).
+
+Build input values can be specified via API using the `inputs` field in the start build request payload, where the `inputs` value is an JSON `object` whose keys correspond to input IDs. 
+
+For example, builds for the following workflow
+
+{{< highlight yaml "style=paraiso-dark">}}
+workflows:
+  build-inputs:
+    inputs:
+      stringInput:
+        description: String value
+        required: true
+        type: string
+      booleanInput:
+        description: Boolean value
+        required: true
+        type: boolean
+      numberInput:
+        description: Numeric value
+        required: false
+        type: number
+        default: 0
+    scripts:
+      - ...
+{{< /highlight >}}
+
+can be started with HTTP request
+
+{{< highlight bash "style=paraiso-dark">}}
+curl -H "Content-Type: application/json" \
+     -H "x-auth-token: <token>" \
+     -d '{
+       "appId": "<app-id>",
+       "workflowId": "build-inputs",
+       "inputs": {
+         "stringInput": "string value",
+         "booleanInput": true,
+         "numberInput": 5,
+       }
+     }' \
+     -X POST https://api.codemagic.io/builds
+{{< /highlight >}}

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -1,7 +1,7 @@
 ---
 title: Build inputs
 description: Specify optional inputs that are passed to the workflow when starting a build
-weight: 6
+weight: 3
 ---
 
 ## Overview

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -12,6 +12,8 @@ Inputs are workflow-specific and are defined in `codemagic.yaml` under the `inpu
 
 ### Minimal example
 
+This example configures one input with the ID `name`. Unless given another value when starting a build, `name` defaults to `Codemagic`.
+
 {{< highlight yaml "style=paraiso-dark">}}
 workflows:
   greetings:
@@ -28,7 +30,7 @@ workflows:
 All inputs must be specified to successfully start a build, either by providing a `default` value in the YAML configuration, or giving a one-off value when starting the build. 
 
 {{<notebox>}}
-**Note**: Builds will fail if invalid values are provided (strings for numbers inputs, undefined choice options, etc.) or values are missing.
+**Note**: Builds will fail if invalid values are provided (strings for number inputs, undefined choice options, etc.) or values are missing.
 {{</notebox>}}
 
 ### Starting builds manually via Codemagic UI
@@ -37,19 +39,9 @@ When starting a build via the Codemagic UI, you will automatically be prompted t
 
 Not entering anything for a string input will result in an empty string, i.e. `""`. For other input types an actual value which matches the requested type must be entered. 
 
-### Starting builds using REST API
-
-To start a build using the REST API, values for inputs that do not define `default` must be included in the `POST` request payload. The inputs which have default value declared in YAML configuration can be omitted from request payload, in that case the specified default will be used.  
-
-Given values must be in accordance with the input definitions, that is:
-- type of the value must match with the input type (numeric values for number inputs, truth values for boolean inputs and textual values for string inputs),
-- value for choice input must be included in the options list. 
-
-For more detailed information on starting builds with inputs using the REST API, refer to the section [below](#specify-inputs-when-starting-builds-with-api). Optional inputs can be omitted from the request payload; their default values will be used instead.
-
 ### Starting builds using webhook events
 
-Only builds that do not rely on inputs can be started with webhook events. If you want to use Git events to automatically trigger builds for workflows with inputs, ensure that all inputs for those workflows have default values.
+Only builds that do not rely on inputs can be started with webhook events. If you want to use Git events or scheduled builds to automatically trigger builds for workflows with inputs, ensure that all inputs for those workflows have default values.
 
 ## YAML schema for inputs
 
@@ -202,48 +194,3 @@ workflows:
           track: alpha
           rollout_fraction: ${{ inputs.rolloutFraction }}
 {{< /highlight >}}
-
-## Specify inputs when starting builds with API
-
-Builds for workflows which have inputs without default values cannot be started unless values for those inputs are specified. This also applies when starting builds using [API](/rest-api/builds/#start-a-new-build).
-
-Build input values can be specified via API using the `inputs` field in the start build request payload, where the `inputs` value is an JSON `object` whose keys correspond to input IDs. 
-
-For example, builds for the following workflow
-
-{{< highlight yaml "style=paraiso-dark">}}
-workflows:
-  build-inputs:
-    inputs:
-      stringInput:
-        description: String value
-        type: string
-      booleanInput:
-        description: Boolean value
-        type: boolean
-      numberInput:
-        description: Numeric value
-        type: number
-        default: 0
-    scripts:
-      - ...
-{{< /highlight >}}
-
-can be started with HTTP request
-
-{{< highlight bash "style=paraiso-dark">}}
-curl -H "Content-Type: application/json" \
-     -H "x-auth-token: <token>" \
-     -d '{
-       "appId": "<app-id>",
-       "workflowId": "build-inputs",
-       "inputs": {
-         "stringInput": "string value",
-         "booleanInput": true,
-         "numberInput": 5
-       }
-     }' \
-     -X POST https://api.codemagic.io/builds
-{{< /highlight >}}
-
-Note that in the above HTTP request `inputs.numberInput` is actually optional and could have been omitted from request payload as `numberInput` has a default value. In case of omission, the default value `0` would be used.

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -34,9 +34,7 @@ All inputs must be specified to successfully start a build, either by providing 
 When starting a build via the Codemagic UI, you will automatically be prompted to enter the inputs. Inputs that have predefined default values will be prefilled with those values from configuration file. All other inputs must be manually entered before the build can be started.
 
 {{<notebox>}}
-**Note on inputs without default values:**
-
-Not entering anything for a string input will result in an empty string, i.e. `""`. Boolean inputs default to `false` in the UI. For other input types, an actual value that matches the requested type must be entered.
+Not entering anything for a string input will result in an empty string, i.e. `""`.
 {{</notebox>}}
 
 ### Starting builds using webhook events
@@ -45,7 +43,7 @@ Only workflows that do not require user input for values can be started with web
 
 ## YAML schema for inputs
 
-Build inputs are defined in `codemagic.yaml` as a mapping `workflow.<workflow_id>.inputs` where keys are input IDs and values are inputs that have the following fields.
+Build inputs are defined in `codemagic.yaml` as a mapping `workflows.<workflow_id>.inputs` where keys are input IDs and values are inputs that have the following fields.
 
 ### `description`
 
@@ -63,7 +61,7 @@ Provide a list of values as options for the `choice` input. Values are all impli
 
 ### `default`
 
-Provide a default value for the input parameter. If `type` is choice, then it must be one of the defined `options`, otherwise value type must match with the `type` definition.
+Provide a default value for the input parameter. If type is `choice`, then it must be one of the defined `options`, otherwise value type must match with the `type` definition.
 
 ## Examples
 

--- a/content/knowledge-codemagic/caching.md
+++ b/content/knowledge-codemagic/caching.md
@@ -1,7 +1,7 @@
 ---
 description: How to configure caching for your builds
 title: Caching
-weight: 3
+weight: 4
 aliases:
   - /flutter/dependency-caching
   - /flutter-configuration/dependency-caching

--- a/content/knowledge-codemagic/codemagic-cli-tools.md
+++ b/content/knowledge-codemagic/codemagic-cli-tools.md
@@ -1,7 +1,7 @@
 ---
 title: Codemagic CLI tools
 description: How to use Codemagic CLI tools locally or in other environments
-weight: 4
+weight: 5
 aliases: 
     - '../yaml/runninglocally'
     - /building/running-locally

--- a/content/knowledge-codemagic/flutter-screenshots-stores.md
+++ b/content/knowledge-codemagic/flutter-screenshots-stores.md
@@ -1,7 +1,7 @@
 ---
 description: Generate screenshots for a Flutter app with golden testing and upload them to the stores
 title: Screenshots
-weight: 5
+weight: 6
 aliases:
   - /flutter/generate-upload-screenshots-stores
   - /flutter-configuration/generate-upload-screenshots-stores

--- a/content/rest-api/builds.md
+++ b/content/rest-api/builds.md
@@ -19,14 +19,15 @@ APIs for managing builds are currently available for developers to preview. Duri
 
 #### Parameters
 
-| **Name**      | **Type** | **Description** |
-| ------------- | -------- | --------------- |
-| `appId`       | `string` | **Required.** The application identifier. |
-| `workflowId`  | `string` | **Required.** The workflow identifier as specified in YAML file. |
-| `branch`      | `string` | Optional. The branch name. Either `branch` or `tag` is **required**. |
-| `tag`         | `string` | Optional. The tag name. Either `branch` or `tag` is **required**. |
-| `environment` | `object` | Optional. Specify environment variables, variable groups, and software versions to override or define in workflow settings. | 
-| `labels`      | `list`   | Optional. Specify labels to be included for the build in addition to existing labels. |
+| **Name**      | **Type** | **Description**                                                                                                                                         |
+|---------------| -------- |---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `appId`       | `string` | **Required.** The application identifier.                                                                                                               |
+| `workflowId`  | `string` | **Required.** The workflow identifier as specified in YAML file.                                                                                        |
+| `branch`      | `string` | Optional. The branch name. Either `branch` or `tag` is **required**.                                                                                    |
+| `tag`         | `string` | Optional. The tag name. Either `branch` or `tag` is **required**.                                                                                       |
+| `environment` | `object` | Optional. Specify environment variables, variable groups, and software versions to override or define in workflow settings.                             |
+| `inputs`      | `object` | Optional. Specify values for build inputs. Read more about from [here](/knowledge-codemagic/build-inputs/#specify-inputs-when-starting-builds-with-api) |
+| `labels`      | `list`   | Optional. Specify labels to be included for the build in addition to existing labels.                                                                   |
 
 
 #### Example
@@ -39,7 +40,7 @@ APIs for managing builds are currently available for developers to preview. Duri
          "workflowId": "<workflow_id>",
          "branch": "<git_branch_name>"
        }' \
-       https://api.codemagic.io/builds
+       -X POST https://api.codemagic.io/builds
 {{< /highlight >}}
 
 #### Pass custom build parameters

--- a/content/rest-api/builds.md
+++ b/content/rest-api/builds.md
@@ -26,7 +26,6 @@ APIs for managing builds are currently available for developers to preview. Duri
 | `branch`      | `string` | Optional. The branch name. Either `branch` or `tag` is **required**.                                                                                    |
 | `tag`         | `string` | Optional. The tag name. Either `branch` or `tag` is **required**.                                                                                       |
 | `environment` | `object` | Optional. Specify environment variables, variable groups, and software versions to override or define in workflow settings.                             |
-| `inputs`      | `object` | Optional. Specify values for build inputs. Read more about from [here](/knowledge-codemagic/build-inputs/#specify-inputs-when-starting-builds-with-api) |
 | `labels`      | `list`   | Optional. Specify labels to be included for the build in addition to existing labels.                                                                   |
 
 


### PR DESCRIPTION
Add new documentation entry to YAML -> Advanced configuration -> Build inputs.

Added article contains the following information:
- describes what "start build inputs" are,
- how to set up build inputs in YAML workflows,
- how to use build inputs when starting builds manually and via API.

**TODOs**
- [ ] Release the feature in Codemagic