### PR TITLE
Add a note with Discord invite

### DIFF
--- a/content/yaml-quick-start/migrating-from-app-center.md
+++ b/content/yaml-quick-start/migrating-from-app-center.md
@@ -5,9 +5,7 @@ weight: 1
 ---
 <p>
 {{<notebox>}}
-**Join our community of mobile experts**
-
-Connect with Codemagic team members and 670+ users in our [Discord community](https://discord.com/invite/ZJsYR6JCBD) to share knowledge and experiences of migrating from App Center and getting started with Codemagic.
+Connect with Codemagic team members and 670+ mobile experts in our [Discord community](https://discord.com/invite/ZJsYR6JCBD) to share knowledge and experiences of migrating from App Center and getting started with Codemagic.
 {{</notebox>}}
 
 ## Quick comparison

--- a/content/yaml-quick-start/migrating-from-app-center.md
+++ b/content/yaml-quick-start/migrating-from-app-center.md
@@ -5,7 +5,7 @@ weight: 1
 ---
 <p>
 {{<notebox>}}
-Connect with Codemagic team members and 670+ mobile experts in our [Discord community](https://discord.com/invite/ZJsYR6JCBD) to share knowledge and experiences of migrating from App Center and getting started with Codemagic.
+Join 670+ mobile experts in our [Discord community](https://discord.com/invite/ZJsYR6JCBD) to share knowledge and experiences of migrating from App Center and getting started with Codemagic.
 {{</notebox>}}
 
 ## Quick comparison

--- a/content/yaml-quick-start/migrating-from-app-center.md
+++ b/content/yaml-quick-start/migrating-from-app-center.md
@@ -3,6 +3,12 @@ title: Migrating from App Center
 description: How to ship your workflows to Codemagic
 weight: 1
 ---
+<p>
+{{<notebox>}}
+**Join our community of mobile experts**
+
+Connect with Codemagic team members and 670+ users in our [Discord community](https://discord.com/invite/ZJsYR6JCBD) to share knowledge and experiences of migrating from App Center and getting started with Codemagic.
+{{</notebox>}}
 
 ## Quick comparison
 


### PR DESCRIPTION
Promote the Discord link to allow users to connect and share experiences with other users. 
The invite link should take users to the dedicated App Center support channel in the desktop app.