### PR TITLE
Remove TestFlight submission requirement for beta groups

### DIFF
--- a/content/partials/yaml-publishing-app-store-connect-environment-variables.md
+++ b/content/partials/yaml-publishing-app-store-connect-environment-variables.md
@@ -26,7 +26,7 @@ publishing:
     # Configuration related to TestFlight (optional)
 
     # Optional boolean, defaults to false. Whether or not to submit the uploaded
-    # build to TestFlight beta review. Required for distributing to beta groups.
+    # build to TestFlight beta review.
     # Note: This action is performed during post-processing.
     submit_to_testflight: true 
 
@@ -36,8 +36,7 @@ publishing:
     # Note: This action is performed during post-processing.
     expire_build_submitted_for_review: true
 
-    # Specify the names of beta tester groups that will get access to the build 
-    # once it has passed beta review.
+    # Specify the names of beta tester groups that will get access to the build.
     beta_groups: 
       - group name 1
       - group name 2

--- a/content/partials/yaml-publishing-app-store-connect-team-integration.md
+++ b/content/partials/yaml-publishing-app-store-connect-team-integration.md
@@ -31,7 +31,7 @@ workflows:
         # Configuration related to TestFlight (optional)
 
         # Optional boolean, defaults to false. Whether or not to submit the uploaded
-        # build to TestFlight beta review. Required for distributing to beta groups.
+        # build to TestFlight beta review.
         # Note: This action is performed during post-processing.
         submit_to_testflight: true
 
@@ -41,8 +41,7 @@ workflows:
         # Note: This action is performed during post-processing.
         expire_build_submitted_for_review: true
 
-        # Specify the names of beta tester groups that will get access to the build 
-        # once it has passed beta review.
+        # Specify the names of beta tester groups that will get access to the build.
         beta_groups: 
           - group name 1
           - group name 2


### PR DESCRIPTION
We no longer require submitting builds to TestFlight beta review as a prerequisite to distributing to beta groups. 