### PR TITLE
Add note about labels being supported for team apps only

### DIFF
--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -490,7 +490,7 @@ workflows:
 If you are building white label apps and use the Codemagic REST API to initiate your builds, labels should be passed as described [here](https://docs.codemagic.io/rest-api/builds/) because it is not possible to override environment variables that will be used as labels.
 
 {{<notebox>}}
-Labels are supported for Team apps only.
+Labels are displayed for Team apps only.
 {{</notebox>}}
 
 ## Working directory

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -488,6 +488,11 @@ workflows:
 {{< /highlight >}}
 
 If you are building white label apps and use the Codemagic REST API to initiate your builds, labels should be passed as described [here](https://docs.codemagic.io/rest-api/builds/) because it is not possible to override environment variables that will be used as labels.
+
+{{<notebox>}}
+Labels are supported for Team apps only.
+{{</notebox>}}
+
 ## Working directory
 
 You may select a working directory globally for the entire workflow or individual scripts only. If not specified, the global working directory defaults to the directory where the repository is cloned (`/Users/builder/clone`). You can override the global working directory by specifying the working directory in the individual steps. Consider the example below:


### PR DESCRIPTION
The docs do not specify that labels work with team apps only. When using them with personal apps, labels are not displayed in the build overview or on the builds page.