### PR TITLE
Update App Store Connect API URLs

### DIFF
--- a/content/partials/app-store-connect-api-key.md
+++ b/content/partials/app-store-connect-api-key.md
@@ -1,4 +1,4 @@
-It is recommended to create a dedicated App Store Connect API key for Codemagic in [App Store Connect](https://appstoreconnect.apple.com/access/api). To do so:
+It is recommended to create a dedicated App Store Connect API key for Codemagic in [App Store Connect](https://appstoreconnect.apple.com/access/integrations/api). To do so:
 
 1. Log in to App Store Connect and navigate to **Users and Access > Integrations >> App Store Connect API**.
 2. Click on the + sign to generate a new API key.

--- a/content/partials/integrations-setup-app-store-connect.md
+++ b/content/partials/integrations-setup-app-store-connect.md
@@ -2,7 +2,7 @@ The Apple Developer Portal integration can be enabled in **Teams > Personal Acco
 
 1. In the list of available integrations, click the **Connect** button for **Developer Portal**.
 2. In the **App Store Connect API key name**, provide a name for the key you are going to set up the integration with. This is for identifying the key in Codemagic.
-3. Enter the **Issuer ID** related to your Apple Developer account. You can find it above the table of active keys on the Integrations tab of the [Users and Access](https://appstoreconnect.apple.com/access/api) page.
+3. Enter the **Issuer ID** related to your Apple Developer account. You can find it above the table of active keys on the Integrations tab of the [Users and Access](https://appstoreconnect.apple.com/access/integrations/api) page.
 4. Enter the **Key ID** of the key to be used for code signing.
 5. In the **API key** field, upload the private API key downloaded from App Store Connect.
 6. Click **Save** to finish the setup.


### PR DESCRIPTION
iOS code signing sections that describe App Store Connect API key generation process reference outdated App Store Connect links.