### PR TITLE
Update building-a-dotnet-maui-app.md

### DIFF
--- a/content/yaml-quick-start/building-a-dotnet-maui-app.md
+++ b/content/yaml-quick-start/building-a-dotnet-maui-app.md
@@ -302,8 +302,8 @@ workflows:
           ./dotnet-install.sh --install-dir $DOTNET_PATH
       - name: Install MAUI
         script: | 
-          $DOTNET_BIN nuget locals all --clear 
-          $DOTNET_BIN workload install ios maui \
+          $DOTNET nuget locals all --clear 
+          $DOTNET workload install ios maui \
             --source https://aka.ms/dotnet6/nuget/index.json \
             --source https://api.nuget.org/v3/index.json      
       - name: Set Info.plist values
@@ -326,7 +326,7 @@ workflows:
           PROFILE_NAME=$(find ~/Library/MobileDevice/Provisioning\ Profiles -name "*.mobileprovision" -execdir sh -c '/usr/libexec/PlistBuddy -c "print :Name" /dev/stdin <<< $(security cms -D -i {})' \;)
           
           cd src
-          $DOTNET_BIN publish -f net6.0-ios \
+          $DOTNET publish -f net6.0-ios \
             -c Release \
             -p:BuildIpa=True \
             -p:ApplicationDisplayVersion="1.0.0" \
@@ -364,7 +364,7 @@ workflows:
       - name: Install MAUI
         script: | 
           $DOTNET nuget locals all --clear 
-          $DOTNET_BIN workload install android maui \
+          $DOTNET workload install android maui \
             --source https://aka.ms/dotnet6/nuget/index.json \
             --source https://api.nuget.org/v3/index.json      
       - name: Build
@@ -377,7 +377,7 @@ workflows:
           fi
           
           cd src
-          $DOTNET_BIN publish -f net6.0-android \
+          $DOTNET publish -f net6.0-android \
             -c Release \
             -p:AndroidKeyStore=True \
             -p:AndroidSigningKeyStore=$CM_KEYSTORE_PATH \


### PR DESCRIPTION
PR to fix the typo

After some investigation, I found that using `$DOTNET_BIN` does not exist, and the actual variable is `DOTNET`, which is also defined in the yaml.

so the correct reference is below
$DOTNET nuget locals all --clear resolves the issue. 

This applies to other scripts as well, using `$DOTNET_BIN`