### PR TITLE
Cleanup after Intel deprecation

### DIFF
--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -149,7 +149,7 @@ The instance types and hardware specifications can be found below.
 | Linux VM                 | 8 vCPUs, 32 GB memory                                                           |
 | Windows VM               | 8 vCPUs, 32 GB memory  
 
-If you are planning to run instrumentation tests with Android emulators, it is advised to use Linux instances. Please note that Android emulators are not available on macOS M1 or M2 VMs.
+If you are planning to run instrumentation tests with Android emulators, it is advised to use Linux instances. Please note that Android emulators are not available on macOS M1 or M2 VMs due to the Apple Virtualization Framework not supporting nested virtualization.
 
 If you need more powerful Linux or macOS machines, please contact us [here](https://codemagic.io/contact/).
 

--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -22,18 +22,18 @@ Postpaid minutes are billed on the first day of the following month in which the
 
 Usage on macOS M1 VM that exceeds 500 minutes is charged at the rate shown below.
 
-Builds on macOS Intel VM, Linux, and Windows do not have free build minutes. The per-minute pricing for each instance type is shown below.
+Builds on Linux and Windows do not have free build minutes. The per-minute pricing for each instance type is shown below.
 
 | **Item**                     | **Price**                          |
 | ---------------------------- | ---------------------------------  |
-| macOS (M1 & Intel) VM        | $0.095 / minute                    |
+| macOS (M1, M2) VM        | $0.095 / minute                    |
 | Linux & Windows VMs          | $0.045 / minute                    |
 
 ## Pricing for Teams
 
 ### 1. Pay-as-you-go
 
-For teams, all build minutes using macOS M1 VM, macOS Intel VM, and Linux VM are charged at the rates shown below. 
+For teams, all build minutes using macOS M1 VM, macOS M2 VM, and Linux VM are charged at the rates shown below. 
 
 Each extra build concurrency allows running an additional build in parallel. For example, adding two extra build concurrencies allows running a total of three builds in parallel. 
 
@@ -44,14 +44,11 @@ Each additional concurrency is $49/month and you will be billed for each concurr
 
 | **Item**                     | **Price**                         |
 | ---------------------------- | --------------------------------- | 
-| macOS (M1 & Intel) VM        | $0.095 / minute                   |                                                                                                                                   
+| macOS (M1, M2) VM        | $0.095 / minute                   |                                                                                                                                   
 | Linux & Windows VMs          | $0.045 / minute                   |                                                                       
 | Extra build concurrency      | $49 / month                       | 
 
-Consider an annual or Enterprise plan if more than three concurrent builds are required or if you would like unlimited build minutes on macOS (Intel and Apple Silicon M2), Linux, and Windows instances. 
-
-
-macOS M2 is not currently available as a pay-as-you-go instance type but is available for the fixed annual plan as described below.
+Consider an annual or Enterprise plan if more than three concurrent builds are required or if you would like unlimited build minutes on macOS (Apple Silicon M2), Linux, and Windows instances. 
 
 ### 2. Fixed Annual Plan
 
@@ -149,11 +146,10 @@ The instance types and hardware specifications can be found below.
 | ------------------------ | --------------------------------------------------------------------------------|
 | macOS M2 VM              | Mac mini M2 8-core CPU / 8GB RAM                                                |
 | macOS M1 VM              | 3.2GHz Quad Core / 8GB                                                          |
-| macOS Intel VM           | 3.7GHz Quad Core / 32GB                                                         |
 | Linux VM                 | 8 vCPUs, 32 GB memory                                                           |
 | Windows VM               | 8 vCPUs, 32 GB memory  
 
-If you are planning to run instrumentation tests with Android emulators, it is advised to use Linux instances. Android emulators are more stable on Linux VMs than on macOS VMs. Also, please note that Android emulators are not available on macOS M1 or M2 VMs.
+If you are planning to run instrumentation tests with Android emulators, it is advised to use Linux instances. Please note that Android emulators are not available on macOS M1 or M2 VMs.
 
 If you need more powerful Linux or macOS machines, please contact us [here](https://codemagic.io/contact/).
 

--- a/content/knowledge-others/install-unity-version.md
+++ b/content/knowledge-others/install-unity-version.md
@@ -174,7 +174,7 @@ Use the Unity version you installed on the machine:
 workflows:
   unity-android-workflow:
       name: Unity Android Workflow
-      instance_type: mac_pro
+      instance_type: linux_x2
       max_build_duration: 120
       environment:
         groups:
@@ -187,8 +187,7 @@ workflows:
           BUILD_SCRIPT: BuildAndroid
           PACKAGE_NAME: "io.codemagic.unity" # <-- Put your package name here e.g. com.domain.myapp
         android_signing:
-        - unity_test
-        xcode: latest
+          - unity_test
       triggering:
         events:
           - push

--- a/content/specs/versions-macos.md
+++ b/content/specs/versions-macos.md
@@ -6,7 +6,7 @@ aliases:
 weight: 1
 ---
 
-Depending on the Xcode version that you specify in **Build Settings** or in `codemagic.yaml` file, Codemagic will use a different build machine type with different versions of preinstalled software:
+Select the desired build machine by specifying the Xcode version and instance type in your workflow settings. See the available options below.
 
 ## Apple silicon machines
 
@@ -38,29 +38,6 @@ Depending on the Xcode version that you specify in **Build Settings** or in `cod
 
 {{< tab header="Xcode 15" >}}
 {{< include "/partials/specs/versions-macos-silicon-xcode-15.md" >}}
-{{< /tab >}}
-
-{{< /tabpane >}}
-
-&nbsp;&nbsp;
-## Intel-based machines
-
-{{< tabpane >}}
-
-{{< tab header="Xcode 14.2" >}}
-{{< include "/partials/specs/versions-macos-intel-xcode-14-2.md" >}}
-{{< /tab >}}
-
-{{< tab header="Xcode 13.3 - 14.1" >}}
-{{< include "/partials/specs/versions-macos-intel-xcode-13-3.md" >}}
-{{< /tab >}}
-
-{{< tab header="Xcode 13.0 - 13.2" >}}
-{{< include "/partials/specs/versions-macos-intel-xcode-13-0.md" >}}
-{{< /tab >}}
-
-{{< tab header="Xcode 12.5" >}}
-{{< include "/partials/specs/versions-macos-intel-xcode-12-5.md" >}}
 {{< /tab >}}
 
 {{< /tabpane >}}

--- a/content/troubleshooting/common-android-issues.md
+++ b/content/troubleshooting/common-android-issues.md
@@ -75,7 +75,7 @@ Note: You'll have to completely upgrade all dependencies that require JCenter to
 ### Java heap space out of memory error for M1 builds
 
 ###### Description
-Builds succeed on Mac Pro machines but fail on M1 machines with the below error:
+Builds fail on M1 machines with the below error:
 
     ERROR:: R8: java.lang.OutOfMemoryError: Java heap space
     FAILURE: Build failed with an exception.

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -187,7 +187,7 @@ The main sections in each workflow are described below.
 
 <br>
 {{<notebox>}}
-**Note:** The `linux_x2` and `windows_x2` are only available for teams and users with [billing enabled](../billing/billing/). `mac_mini_m2` is only available on fixed price annual plan. 
+**Note:** Instance types `linux_x2`, `windows_x2` and `mac_mini_m2` are only available for teams and users with [billing enabled](../billing/billing/). 
 {{</notebox>}}
 
 ### Build inputs

--- a/content/yaml-quick-start/building-a-unity-app.md
+++ b/content/yaml-quick-start/building-a-unity-app.md
@@ -150,7 +150,7 @@ To deactivate a Unity license on the build machine, add the following script ste
 
 {{< tabpane >}}
 
-{{< tab header="mac (Intel) & Linux instance types" >}}
+{{< tab header="Linux instances" >}}
 {{< highlight yaml "style=paraiso-dark">}}
   publishing:
     scripts:

--- a/content/yaml-quick-start/building-a-vr-oculus-app.md
+++ b/content/yaml-quick-start/building-a-vr-oculus-app.md
@@ -125,7 +125,7 @@ To deactivate a Unity license on the build machine, add the following script ste
 
 {{< tabpane >}}
 
-{{< tab header="mac (Intel) & Linux instance types" >}}
+{{< tab header="Linux instances" >}}
 {{< highlight yaml "style=paraiso-dark">}}
   publishing:
     scripts:

--- a/static/codemagic-yaml-cheatsheet.html
+++ b/static/codemagic-yaml-cheatsheet.html
@@ -2140,8 +2140,8 @@ ul.-also-see.-also-see.-also-see > li > em {
 <p>Define a section at the top of the .yaml file and reuse it later in different workflows.</p>
 
 <pre><code class="language-yaml">definitions:
-  instance_mac_pro: &amp;instance_mac_pro
-    instance_type: mac_pro
+  instance_mac_mini_m2: &amp;instance_mac_mini_m2
+    instance_type: mac_mini_m2
     max_build_duration: 120
   env_versions: &amp;env_versions
     flutter: stable
@@ -2159,7 +2159,7 @@ ul.-also-see.-also-see.-also-see > li > em {
 <pre data-line="4,6,8"><code class="language-yaml">workflows:
   ios-release:
     name: iOS release
-    &lt;&lt;: *instance_mac_pro
+    &lt;&lt;: *instance_mac_mini_m2
     environment:
       &lt;&lt;: *env_versions
     scripts:


### PR DESCRIPTION
Remove Intel machines specs from docs as well as references to `mac_pro`. 

Further cleanup will follow in https://github.com/codemagic-ci-cd/codemagic-docs/pull/2698