### PR TITLE
Remove references to M1

### DIFF
--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -8,7 +8,7 @@ weight: 2
 
 This plan is suitable for individuals working on hobby or indie projects. You can also use this plan for running a proof of concept.
 
-Individuals receive **500 free minutes** per month on macOS M1 machines on a personal account. These 500 free minutes are **reset on the 1st of each month**. Free minutes are not available if you are using a Team. 
+Individuals receive **500 free minutes** per month on macOS M2 machines on a personal account. These 500 free minutes are **reset on the 1st of each month**. Free minutes are not available if you are using a Team. 
 
 You cannot invite collaborators to an individual plan.
 
@@ -16,24 +16,24 @@ To start using Codemagic for free, [sign up here](https://codemagic.io/signup).
 
 ### 2. Buying Additional Minutes
 
-You can enable billing on personal accounts and pay for any additional minutes you want to use. You will still have **500 free build minutes** on macOS M1 VM. To enable billing, proceed [here](https://codemagic.io/billing). 
+You can enable billing on personal accounts and pay for any additional minutes you want to use. You will still have **500 free build minutes** on macOS M2 VM. To enable billing, proceed [here](https://codemagic.io/billing). 
 
 Postpaid minutes are billed on the first day of the following month in which they were used.
 
-Usage on macOS M1 VM that exceeds 500 minutes is charged at the rate shown below.
+Usage on macOS M2 VM that exceeds 500 minutes is charged at the rate shown below.
 
 Builds on Linux and Windows do not have free build minutes. The per-minute pricing for each instance type is shown below.
 
 | **Item**                     | **Price**                          |
 | ---------------------------- | ---------------------------------  |
-| macOS (M1, M2) VM        | $0.095 / minute                    |
+| macOS (M2) VM        | $0.095 / minute                    |
 | Linux & Windows VMs          | $0.045 / minute                    |
 
 ## Pricing for Teams
 
 ### 1. Pay-as-you-go
 
-For teams, all build minutes using macOS M1 VM, macOS M2 VM, and Linux VM are charged at the rates shown below. 
+For teams, all build minutes using macOS M2 VM, and Linux VM are charged at the rates shown below. 
 
 Each extra build concurrency allows running an additional build in parallel. For example, adding two extra build concurrencies allows running a total of three builds in parallel. 
 
@@ -44,7 +44,7 @@ Each additional concurrency is $49/month and you will be billed for each concurr
 
 | **Item**                     | **Price**                         |
 | ---------------------------- | --------------------------------- | 
-| macOS (M1, M2) VM        | $0.095 / minute                   |                                                                                                                                   
+| macOS (M2) VM        | $0.095 / minute                   |                                                                                                                                   
 | Linux & Windows VMs          | $0.045 / minute                   |                                                                       
 | Extra build concurrency      | $49 / month                       | 
 
@@ -145,17 +145,16 @@ The instance types and hardware specifications can be found below.
 | **Item**                 | **Specification**                                                               |
 | ------------------------ | --------------------------------------------------------------------------------|
 | macOS M2 VM              | Mac mini M2 8-core CPU / 8GB RAM                                                |
-| macOS M1 VM              | 3.2GHz Quad Core / 8GB                                                          |
 | Linux VM                 | 8 vCPUs, 32 GB memory                                                           |
 | Windows VM               | 8 vCPUs, 32 GB memory  
 
-If you are planning to run instrumentation tests with Android emulators, it is advised to use Linux instances. Please note that Android emulators are not available on macOS M1 or M2 VMs due to the Apple Virtualization Framework not supporting nested virtualization.
+If you are planning to run instrumentation tests with Android emulators, it is advised to use Linux instances. Please note that Android emulators are not available on macOS M2 VMs due to the Apple Virtualization Framework not supporting nested virtualization.
 
 If you need more powerful Linux or macOS machines, please contact us [here](https://codemagic.io/contact/).
 
 For Linux instances, details of the hardware specification, system information, and pre-installed software can be found [here](https://docs.codemagic.io/specs/versions-linux/)
 
-For macOS instances, details of the hardware specification, system information, and pre-installed software can be found [here](https://docs.codemagic.io/specs/versions3/)  
+For macOS instances, details of the hardware specification, system information, and pre-installed software can be found [here](https://docs.codemagic.io/specs/versions-macos/)  
 
 For Windows instances, details of the hardware specification, system information, and pre-installed software can be found [here](https://docs.codemagic.io/specs/versions-windows/)  
 

--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -33,7 +33,7 @@ Builds on Linux and Windows do not have free build minutes. The per-minute prici
 
 ### 1. Pay-as-you-go
 
-For teams, all build minutes using macOS M2 VM, and Linux VM are charged at the rates shown below. 
+For teams, all build minutes using macOS M2 VM and Linux VM are charged at the rates shown below. 
 
 Each extra build concurrency allows running an additional build in parallel. For example, adding two extra build concurrencies allows running a total of three builds in parallel. 
 

--- a/content/getting-started/about-codemagic.md
+++ b/content/getting-started/about-codemagic.md
@@ -29,7 +29,7 @@ Workflows are configured in code using a YAML configuration file which can be ch
 Flutter developers can also choose to set up their workflows using a graphical user interface called the “Workflow Editor”.
 
 ## Infrastructure
-Codemagic’s infrastructure is centered around the powerful Apple silicon M1 and M2(arm64) machines allowing for faster builds than the previous generation of macOS machines. Linux and Windows machines are also available for all customers. 
+Codemagic’s infrastructure is centered around the powerful Apple silicon M2 (arm64) machines allowing for faster builds than the previous generation of macOS machines. Linux and Windows machines are also available for all customers. 
 
 The following documentation pages show the hardware specifications for each instance type:
 
@@ -52,7 +52,7 @@ Please refer to the following documentation to see the software pre-installed on
 If you need to run parallel builds you can add additional concurrencies as your needs grow. The free tier and pay-as-you-go plan includes one concurrency to begin with but can be increased to a total of three. The Annual plan and Enterprise plans start with three concurrencies and an unlimited number of concurrencies can be added at any time during your subscription period. 
 
 ## Pricing
-Individuals and hobbyists can get started with Codemagic using its free tier which offers 500 free build minutes per month and lets you build on Apple silicon M1 machines. This quota is reset at the beginning of each month. 
+Individuals and hobbyists can get started with Codemagic using its free tier which offers 500 free build minutes per month and lets you build on Apple silicon M2 machines. This quota is reset at the beginning of each month. 
 
 For development teams with limited budgets, the Codemagic pay-as-you-go plan offers an affordable way to get started with CI/CD. You only pay for the minutes you consume and the additional concurrencies you add. 
 

--- a/content/knowledge-codemagic/machine-type.md
+++ b/content/knowledge-codemagic/machine-type.md
@@ -28,9 +28,8 @@ For Flutter projects configured via the Flutter workflow editor, the build machi
 
 The following build machine types are provided by Codemagic:
 
-1. Apple silicon M1 Mac mini
-2. Apple silicon M2 Mac mini
-3. Linux
-4. Windows
+1. Apple silicon M2 Mac mini
+2. Linux
+3. Windows
 
 For more information about the machine specifications, please check [this page](https://docs.codemagic.io/specs/versions-macos/).

--- a/content/knowledge-others/import-variables-from-env-file.md
+++ b/content/knowledge-others/import-variables-from-env-file.md
@@ -98,7 +98,7 @@ The following script first loads the **settings.env** file so you can read its v
 {{< highlight yaml "style=paraiso-dark">}}
 workflow-name:
   name: Workflow name
-  instance_type: mac_mini_m1
+  instance_type: mac_mini_m2
     max_build_duration: 120
     environment:
       groups:

--- a/content/knowledge-white-label/white-label-apps-overview.md
+++ b/content/knowledge-white-label/white-label-apps-overview.md
@@ -101,14 +101,14 @@ In addition to unit and integration testing, developers and QA teams still want 
 
 Even though it’s possible to build both iOS and Android apps on macOS machines, we offer Linux machines as well. If Linux machines are preferred for Android builds, then you should create separate workflows for iOS and Android builds and set the `instance_type` property in your *codemagic.yaml*. 
 
-- For iOS, use the latest Apple silicon M1 machine where possible. Set the instance type to `mac_mini_m1` in the `codemagic.yaml` configuration file.
+- For iOS, use the latest Apple silicon machine where possible. Set the instance type to `mac_mini_m2` in the `codemagic.yaml` configuration file.
 - For Android builds, use premium Linux machines. Set the instance type to `linux_x2` in the `codemagic.yaml` configuration file.
 
 {{< highlight yaml "style=paraiso-dark">}}
 workflows:
   ios-dev-release:
     name: iOS dev release
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
   ....
 
   android-dev-release:

--- a/content/partials/monorepo-apps.md
+++ b/content/partials/monorepo-apps.md
@@ -12,7 +12,7 @@ To begin with, **codemagic.yaml** file must be created in the root directory of 
 workflows:
   default-workflow:
     name: Default workflow
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     max_build_duration: 60
     environment:
       flutter: stable

--- a/content/partials/quickstart/create-yaml-intro.md
+++ b/content/partials/quickstart/create-yaml-intro.md
@@ -17,7 +17,7 @@ workflows:
     sample-workflow:
         name: Codemagic Sample Workflow
         max_build_duration: 120
-        instance_type: mac_mini_m1
+        instance_type: mac_mini_m2
 {{< /highlight >}}
 
 

--- a/content/partials/white-label-apps.md
+++ b/content/partials/white-label-apps.md
@@ -24,7 +24,7 @@ For example, for each version of your app, you could create a workflow in the co
 workflows:
   version-one:
     name: Version one
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     environment:
       groups:
         ...
@@ -38,7 +38,7 @@ workflows:
       ...
   version-two:
     name: Version two
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     environment:
       groups:
         ...

--- a/content/rest-api/builds.md
+++ b/content/rest-api/builds.md
@@ -64,7 +64,7 @@ APIs for managing builds are currently available for developers to preview. Duri
       "flutter": "v1.12.13+hotfix.9"
     }
   },
-  "instanceType": "mac_mini_m1"
+  "instanceType": "mac_mini_m2"
 }
 {{< /highlight >}}
 

--- a/content/troubleshooting/common-ios-issues.md
+++ b/content/troubleshooting/common-ios-issues.md
@@ -147,14 +147,14 @@ This issue is known to be fixed on the `master` channel.
 
 
 
-### Mac M1 issues
+### Mac M2 issues
 
 ###### Builds not starting
 
-Builds not starting at all even though the team has access to `mac_mini_m1` instance.
+Builds not starting at all even though the team has access to the `mac_mini_m2` instance.
 
 **Solution**:
-This error occurs on M1 machines when the `xcode` property is not set to version 13.x. Please configure your workflow to use Xcode version 13 or above.
+This error occurs on M2 machines when the `xcode` property is set to a version that is not supported. Please configure your workflow to use Xcode version 15 or above.
 
 
 ###### Builds failing intermittently
@@ -262,7 +262,7 @@ The solution is to update the path to your project. In order to target apps insi
 workflows:
   default-workflow:
     name: Default workflow
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     max_build_duration: 120
     # Specify path to the app folder like this
     working_directory: ios/path-to-your-project

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -118,7 +118,7 @@ workflows:
     labels:
       - QA
       - ${TENANT_NAME}
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     max_build_duration: 60
     inputs: # more information about build inputs:https://docs.codemagic.io/knowledge-codemagic/build-inputs/
       name: # input ID
@@ -163,7 +163,7 @@ You can use `codemagic.yaml` to define several workflows for building a project.
 workflows:
   my-workflow:                   # workflow ID
     name: My workflow name       # workflow name displayed in Codemagic UI
-    instance_type: mac_mini_m1   # machine instance type
+    instance_type: mac_mini_m2   # machine instance type
     max_build_duration: 60       # build duration in minutes (min 1, max 120)
     environment:
     cache:
@@ -180,7 +180,6 @@ The main sections in each workflow are described below.
 `instance_type:` specifies the [build machine type](../specs/machine-type) to use for the build. The supported build machines are:
 | **Instance Type** | **Build Machine** |
 | ------------- | -----------------  |
-| `mac_mini_m1`    | Apple silicon M1 Mac mini |
 | `mac_mini_m2`    | Apple silicon M2 Mac mini |
 | `linux_x2`  | Linux |
 | `windows_x2`  | Windows |

--- a/content/yaml-code-signing/ios-simulator-builds.md
+++ b/content/yaml-code-signing/ios-simulator-builds.md
@@ -73,7 +73,7 @@ workflows:
   simulator-native-ios:
     name: iOS simulator build
     max_build_duration: 120
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     environment:
       vars:
         XCODE_WORKSPACE: "your_workspace_name.xcworkspace"
@@ -110,7 +110,7 @@ workflows:
   maui-ios-simulator-build:
     name: Dotnet MAUI iOS Simulator
     max_build_duration: 120
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     environment:
       xcode: latest
       vars:

--- a/content/yaml-quick-start/building-a-dotnet-maui-app.md
+++ b/content/yaml-quick-start/building-a-dotnet-maui-app.md
@@ -282,7 +282,7 @@ workflows:
   maui-ios:
     name: Dotnet MAUI iOS
     max_build_duration: 120
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     integrations:
       app_store_connect: codemagic-api
     environment:
@@ -345,7 +345,7 @@ workflows:
   maui-android:
     name: Dotnet MAUI Android
     max_build_duration: 120
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     environment:
       android_signing:
         - codemagic-key

--- a/content/yaml-quick-start/building-a-native-android-app.md
+++ b/content/yaml-quick-start/building-a-native-android-app.md
@@ -88,7 +88,7 @@ workflows:
   native-android:
     name: Native Android
     max_build_duration: 120
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     environment:
       android_signing:
         - keystore_reference

--- a/content/yaml-quick-start/building-a-native-ios-app.md
+++ b/content/yaml-quick-start/building-a-native-ios-app.md
@@ -85,7 +85,7 @@ workflows:
   ios-native-workflow:
     name: iOS Native
     max_build_duration: 120
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     integrations:
       app_store_connect: codemagic
     environment:

--- a/content/yaml-quick-start/building-a-react-native-app.md
+++ b/content/yaml-quick-start/building-a-react-native-app.md
@@ -284,7 +284,7 @@ workflows:
   react-native-android:
     name: React Native Android
     max_build_duration: 120
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     environment:
       android_signing:
         - keystore_reference
@@ -337,7 +337,7 @@ workflows:
   react-native-ios:
     name: React Native iOS
     max_build_duration: 120
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     integrations:
       app_store_connect: codemagic
     environment:

--- a/content/yaml-quick-start/building-a-unity-app.md
+++ b/content/yaml-quick-start/building-a-unity-app.md
@@ -160,7 +160,7 @@ To deactivate a Unity license on the build machine, add the following script ste
 {{< /highlight >}}
 {{< /tab >}}
 
-{{% tab header="Mac M1 instances" %}}
+{{% tab header="Mac M2 instances" %}}
 {{< highlight yaml "style=paraiso-dark">}}
   publishing:
     scripts:

--- a/content/yaml-quick-start/building-a-vr-oculus-app.md
+++ b/content/yaml-quick-start/building-a-vr-oculus-app.md
@@ -135,7 +135,7 @@ To deactivate a Unity license on the build machine, add the following script ste
 {{< /highlight >}}
 {{< /tab >}}
 
-{{% tab header="Mac M1 instances" %}}
+{{% tab header="Mac M2 instances" %}}
 {{< highlight yaml "style=paraiso-dark">}}
   publishing:
     scripts:

--- a/content/yaml-quick-start/migrating-from-app-center.md
+++ b/content/yaml-quick-start/migrating-from-app-center.md
@@ -66,7 +66,7 @@ Join 670+ mobile experts in our [Discord community](https://discord.com/invite/Z
 Building Project | [**5m 4s**](https://codemagic.io/app/660936c197f2bee5b7353663/build/6613924355709ef49738d259) | [6m 13s](https://codemagic.io/app/660936c197f2bee5b7353663/build/660abe3a7eedcf9b3279f83d) | [39m 27s](https://appcenter.ms/orgs/Nevercode_Codemagic/apps/Benchmark_iOS/build/branches/main/builds/9)
 Overall improvement | 778% | 635% | 1
 
-As it can be seen, building the benchmark project took around 5-6 minutes with Codemagic macOS M1 and M2 machines while the build completed in 39 minutes 24 seconds with App Center. Worth pointing out that App Center limits free tier users to 30 minutes build duration per build and based on the performance rate above, the 30 minute build duration range will not allow you to complete your builds due to the fact that they will timeout.
+As it can be seen, building the benchmark project took around 5-6 minutes with Codemagic macOS M1 (now deprecated) and M2 machines while the build completed in 39 minutes 24 seconds with App Center. Worth pointing out that App Center limits free tier users to 30 minutes build duration per build and based on the performance rate above, the 30 minute build duration range will not allow you to complete your builds due to the fact that they will timeout.
 
 ### Support options
 

--- a/content/yaml-quick-start/white-label-getting-started.md
+++ b/content/yaml-quick-start/white-label-getting-started.md
@@ -299,7 +299,7 @@ Your final `codemagic.yaml` file should look something like this:
 workflows:
   android-client-release:
     name: Android client release
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     labels:
       - ${CLIENT_ID} # Helpful when you open your Codemagic's builds page 
     environment:
@@ -346,7 +346,7 @@ workflows:
 workflows:
   ios-client-release:
     name: iOS client release
-    instance_type: mac_mini_m1
+    instance_type: mac_mini_m2
     labels:
       - ${CLIENT_ID} # Helpful when you open your Codemagic's builds page  
     environment:

--- a/content/yaml-testing/testing.md
+++ b/content/yaml-testing/testing.md
@@ -68,7 +68,7 @@ scripts:
 {{< tab header="Android" >}}
 {{<markdown>}}
 {{<notebox>}}
-Due to limitations by Apple silicon, the Apple Virtualization API doesn’t support nested virtualization required for Android emulators. To use Android emulators in macOS M1 workflows, please use third-party service integrations such as emulator.wtf, Katalon, Firebase, or AWS Device Farm.
+Due to limitations by Apple silicon, the Apple Virtualization API doesn’t support nested virtualization required for Android emulators. To use Android emulators in macOS workflows, please use third-party service integrations such as emulator.wtf, Katalon, Firebase, or AWS Device Farm.
 {{</notebox>}}
 
 


### PR DESCRIPTION
Now that we have removed M1 machines, we can remove outdated references to M1 instances.