### PR TITLE
Fix: scroll menu to active item

### DIFF
--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -268,8 +268,6 @@ const setInitialPreference = () => {
 }
 // Handle preference change
 const changePreference = (target) => {
-    openActiveCategory()
-
     if (target.hasAttribute('data-js-preference-option')) {
         const bg = document.querySelector('[data-js-preference-bg]')
         const active = document.querySelector('[data-js-preference-option].active')
@@ -354,8 +352,8 @@ const collapsibleListener = () => {
 handleSidebarPosition()
 positionHeaderContents()
 setInitialPreference()
-scrollMenuToActive('[data-js-docs-menu]', true)
 openActiveCategory()
+scrollMenuToActive('[data-js-docs-menu]', true)
 collapsibleListener()
 
 // fix scroll position of default scroll to hash

--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -352,9 +352,9 @@ const collapsibleListener = () => {
 
 // On ready
 handleSidebarPosition()
-scrollMenuToActive('[data-js-docs-menu]', true)
 positionHeaderContents()
 setInitialPreference()
+scrollMenuToActive('[data-js-docs-menu]', true)
 openActiveCategory()
 collapsibleListener()
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -24,6 +24,9 @@ Version: 0.0.1
 @import './modules/tabbed-pane';
 @import './modules/clipboard';
 
+html {
+    scroll-behavior: smooth;
+}
 body {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
In order to fix https://github.com/codemagic-dev/codemagic/issues/653, I had to adjust order of **on ready** calls:
1. `setInitialPreference` to set relevant items be displayed in the menu
2. `openActiveCategory` to open active category
3. Finally, after relevant items are displayed and positioned, `scrollMenuToActive` to scroll to active menu item

Adjusting the order allowed to remove duplicate `openActiveCategory` call.

# QA locally
Scroll to active menu item works for:
✅ YAML menu
✅ Workflow editor menu