### PR TITLE
fix hugo deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
-            - run: curl --location https://github.com/gohugoio/hugo/releases/download/v0.139.2/hugo_extended_0.139.2_Linux-64bit.tar.gz | tar -vxzO hugo > hugo && chmod a+x hugo
+            - run: curl --location https://github.com/gohugoio/hugo/releases/download/v0.139.2/hugo_extended_withdeploy_0.139.2_Linux-64bit.tar.gz | tar -vxzO hugo > hugo && chmod a+x hugo
             - run: ./hugo --environment production --minify
             - run: ./hugo deploy --environment production --invalidateCDN true --maxDeletes -1
 


### PR DESCRIPTION
the `hugo deploy` command was removed from the standard package, more information here https://github.com/gohugoio/hugo/issues/12994