### PR TITLE
update the Jave heap space error workaround with additional error

### DIFF
--- a/content/troubleshooting/common-android-issues.md
+++ b/content/troubleshooting/common-android-issues.md
@@ -72,7 +72,7 @@ Note: You'll have to completely upgrade all dependencies that require JCenter to
 {{</notebox>}}
 
 
-### Java heap space out of memory error
+### Java heap space out of memory error or JVM garbage collector is thrashing
 
 ###### Description
 Builds fail with the below error:
@@ -82,6 +82,12 @@ Builds fail with the below error:
     * What went wrong:
     Execution failed for task ':app:minifyReleaseWithR8'.
     > com.android.tools.r8.CompilationFailedException: Compilation failed to complete
+
+Or
+
+    FAILURE: Build failed with an exception.
+    * What went wrong:
+    Gradle build daemon has been stopped: since the JVM garbage collector is thrashing
 
 
 ###### Solution


### PR DESCRIPTION
Users started reporting an error which is similar to Java heap space
`Gradle build daemon has been stopped: since the JVM garbage collector is thrashing`
The workaround is the same as for Java heap space error

![image](https://github.com/user-attachments/assets/0221779c-6cf1-48bf-8994-cfe73fa8626d)