### PR TITLE
SOC 2 and GCP Marketplace availability

### DIFF
--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -102,9 +102,9 @@ Dedicated **macOS M2** hosts are also available on request. A dedicated host is 
 
 This plan is recommended if you need to go through a **security compliance process**, **vendor registration** or have special requirements such as an **NDA**, **DPA**, **dedicated hosts**, or **custom base images** or other account management services.
 
-Annual invoicing with bank transfer is available for Enterprise plans. Payment is also possible via AWS Marketplace [here](https://aws.amazon.com/marketplace/pp/prodview-hiscwaznkehlo?sr=0-1&ref_=beagle&applicationId=AWSMPContessa)
+Annual invoicing with bank transfer is available for Enterprise plans. Payment is also possible via AWS Marketplace [here](https://aws.amazon.com/marketplace/pp/prodview-hiscwaznkehlo?sr=0-1&ref_=beagle&applicationId=AWSMPContessa) and Google Cloud Marketplace.
 
-Please also note that we have started working towards SOC2 certification and should be certified soon.
+Please also note that we have completed our SOC 2 assessment and the report is available on request. 
 
 If you would like more information about our Enterprise plan, please contact us [here](https://codemagic.io/enterprise/). 
 


### PR DESCRIPTION
* Change wording from certified to SOC2 assessment
* Adding GCP Marketplace beside AWS