### PR TITLE
Yaml Getting Started Documentation Review

### DIFF
--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -186,7 +186,7 @@ The main sections in each workflow are described below.
 
 <br>
 {{<notebox>}}
-**Note:** Instance types `linux_x2`, `windows_x2` and `mac_mini_m2` are only available for teams and users with [billing enabled](../billing/billing/). 
+**Note:** Instance types `linux_x2` and `windows_x2` are only available for teams and users with [billing enabled](../billing/billing/). 
 {{</notebox>}}
 
 ### Build inputs
@@ -330,6 +330,8 @@ cache:
     - ~/.gradle/caches
     - ...
 {{< /highlight >}}
+You can read more about configuring caching for your builds and it's usage limits [here](https://docs.codemagic.io/knowledge-codemagic/caching/)
+
 {{<notebox>}}
 **Note:** Codemagic doesn't support caching symlinks.
 {{</notebox>}}

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -330,7 +330,7 @@ cache:
     - ~/.gradle/caches
     - ...
 {{< /highlight >}}
-You can read more about configuring caching for your builds and it's usage limits [here](https://docs.codemagic.io/knowledge-codemagic/caching/)
+You can read more about configuring caching for your builds and its usage limits [here](https://docs.codemagic.io/knowledge-codemagic/caching/)
 
 {{<notebox>}}
 **Note:** Codemagic doesn't support caching symlinks.


### PR DESCRIPTION
Add link to page on configuring configuring caching for builds and removed `mac_mini_m2` from `instance_type` only available for teams and users with billing enabled.