### PR TITLE
Add troubleshooting section for Flutter build error with localizations

### DIFF
--- a/content/troubleshooting/common-issues.md
+++ b/content/troubleshooting/common-issues.md
@@ -94,3 +94,25 @@ Add your new repository as an application to Codemagic, then retrieve both old a
 
 
 
+### Flutter build error when using localizations
+
+###### Description
+You might encounter a Flutter build error when using localizations in your app, as shown below:
+
+```logs
+    Try correcting the name to the name of an existing getter, or defining a getter or field named 
+    'AppLocalizations'.
+        AppLocalizations.of(context)!.helloWorldString
+        ^
+```
+This happens when the required localization files are not generated during the build process.
+
+###### Solution
+To resolve this issue, include the `flutter gen-l10n` command in your pre-build script, right after `flutter pub get`. This ensures that the necessary localization files are generated before the build process begins.
+
+```bash
+flutter pub get  # Optional if dependencies are already being fetched
+flutter gen-l10n
+```
+
+For more details on setting up localizations, refer to [Flutter's documentation on Localization](https://docs.flutter.dev/ui/accessibility-and-internationalization/internationalization#adding-your-own-localized-messages) (Step 6).


### PR DESCRIPTION
### Pull Request Description: Adding Common Issue for Localization Build Error


### Description:
This pull request adds a new entry to the Common Issues section under Troubleshooting to help users resolve a frequent build error encountered when using localizations in Flutter. The error typically occurs when the necessary localization files are not generated during the build process, resulting in a ` Try correcting the name to the name of an existing getter, or defining a getter or field named  'AppLocalizations'.` error.


### Changes Made:

- Added a new entry to the Common Issues section under Troubleshooting.
- Added the solution to run the `flutter gen-l10n` command in the pre-build script.

### Checklist:

-  The description is concise and follows the format of existing entries.
-  Log output and example scripts are included.
-  Links to official Flutter documentation are provided.
-  Reviewed and tested for accuracy.


### Additional Notes:
Feedback and suggestions for improvement are welcome. If there are any adjustments needed, I'd be happy to make them.