### PR TITLE
rotate deployment key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         env:
-            AWS_ACCESS_KEY_ID: AKIAVIULH47FMHXU2IXE
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
every 90 days we rotate deployment key. This PR remove hardcoded key ID to easy rotate it via GitHub UI