### PR TITLE
minor bugfix/update page titles

### DIFF
--- a/content/specs-macos/xcode-16-0.md
+++ b/content/specs-macos/xcode-16-0.md
@@ -1,5 +1,5 @@
 ---
-title: Xcode 16.0.x (default)
+title: Xcode 16.0.x
 aliases:
 - /specs/versions-macos/
 weight: 100

--- a/content/specs-macos/xcode-16-2.md
+++ b/content/specs-macos/xcode-16-2.md
@@ -1,5 +1,5 @@
 ---
-title: Xcode 16.2.x (edge)
+title: Xcode 16.2.x (default)
 aliases:
 
 weight: 98


### PR DESCRIPTION
page titles did not get updated automatically after Xcode 16.2 became default, here is a fix