### PR TITLE
How to build iOS .app binaries for Flutter apps

### DIFF
--- a/content/partials/app-preview-builds.md
+++ b/content/partials/app-preview-builds.md
@@ -7,7 +7,11 @@ Codemagic allows you to preview your `.app` artifact on an iOS simulator and int
 Note that this feature is available for **teams** on request. Please [contact us](https://codemagic.io/contact/) for more information.
 {{</notebox>}}
 
-## Creating iOS .app binaries for testing
+## Using Workflow Editor to create iOS .app binaries for testing
+
+In the 'Build' section of the Workflow Editor set the 'Mode' to debug. In the 'Build arguments' add `--simulator` next to the iOS '--debug' section.
+
+## Creating iOS .app binaries for testing with codemagic.yaml
 
 To create a `.app` to run on the iOS simulator consult the **codemagic.yaml** samples below.
 

--- a/content/partials/app-preview-builds.md
+++ b/content/partials/app-preview-builds.md
@@ -59,7 +59,7 @@ workflows:
 {{< tab header="Flutter (Flavors)" >}}
 {{<markdown>}}
 
-If you are using Flutter flavors and want to preview a specific flavor make sure that you set the correct value for your flavor's `-scheme` and set the entry point for your flavor using `FLUTTER_TARGET`. 
+If you are using Flutter flavors and want to preview a specific flavor, make sure that you set the correct value for your flavor's `-scheme` and set the entry point for your flavor using `FLUTTER_TARGET`. 
 
 {{< highlight yaml "style=paraiso-dark">}}
 workflows:

--- a/content/partials/app-preview-builds.md
+++ b/content/partials/app-preview-builds.md
@@ -13,7 +13,7 @@ In the 'Build' section of the Workflow Editor set the 'Mode' to debug. In the 'B
 
 ## Creating iOS .app binaries for testing with codemagic.yaml
 
-To create a `.app` to run on the iOS simulator consult the **codemagic.yaml** samples below.
+To create a `.app` to run on the iOS simulator, consult the **codemagic.yaml** samples below.
 
 You should make sure that the following values in the `-destination` string correspond with the macOS instance you are using:
 

--- a/content/partials/app-preview-builds.md
+++ b/content/partials/app-preview-builds.md
@@ -7,6 +7,86 @@ Codemagic allows you to preview your `.app` artifact on an iOS simulator and int
 Note that this feature is available for **teams** on request. Please [contact us](https://codemagic.io/contact/) for more information.
 {{</notebox>}}
 
+## Creating iOS .app binaries for testing
+
+To create a `.app` to run on the iOS simulator consult the **codemagic.yaml** samples below.
+
+You should make sure that the following values in the `-destination` string correspond with the macOS instance you are using:
+
+- `name` corresponds with the one of the devices available on the macOS instance being used.
+- `OS` matches the iOS runtime available on the macOS instance being used.
+
+You can find the macOS specifications that list the available iOS devices and runtimes [here](https://docs.codemagic.io/specs-macos/xcode-16-2/#:~:text=Software%20and%20hardware-,macOS%20machines,-Xcode%2016.2.x).
+
+{{< tabpane >}}
+{{< tab header="Flutter" >}}
+{{<markdown>}}
+Sample **codemagic.yaml** for build an iOS `.app` binary for Flutter projects.
+
+{{< highlight yaml "style=paraiso-dark">}}
+workflows:
+  flutter-ios-simulator:
+    name: Flutter iOS Simulator
+    environment:
+      flutter: 3.27.3
+      xcode: 16.2
+    scripts:
+      - name: install dependencies
+        script: flutter pub get
+      - name: Build unsigned .app
+        script: |  
+          xcodebuild -workspace "ios/Runner.xcworkspace" \
+            -scheme "Runner" \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            -derivedDataPath ios/output
+    artifacts:
+      - ios/output/Build/Products/Debug-iphonesimulator/Runner.app
+{{< /highlight >}}
+
+{{</markdown>}}
+{{< /tab >}}
+
+
+{{< tab header="Flutter (Flavors)" >}}
+{{<markdown>}}
+
+If you are using Flutter flavors and want to preview a specific flavor make sure that you set the correct value for your flavor's `-scheme` and set the entry point for your flavor using `FLUTTER_TARGET`. 
+
+{{< highlight yaml "style=paraiso-dark">}}
+workflows:
+  flutter-flavor-ios-simulator:
+    name: Flutter Flavor iOS Simulator
+    environment:
+      flutter: 3.27.3
+      xcode: 16.2
+      cocoapods: default
+    scripts:
+      - name: install dependencies
+        script: flutter pub get
+      - name: Build unsigned .app
+        script: |  
+          xcodebuild -workspace "ios/Runner.xcworkspace" \
+            -scheme "Runner-dev" \ 
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            FLUTTER_TARGET=lib/main_dev.dart \
+            -derivedDataPath ios/output
+    artifacts:
+      - ios/output/Build/Products/Debug-iphonesimulator/Runner.app
+{{< /highlight >}}
+{{</markdown>}}
+{{< /tab >}}
+{{< /tabpane >}}
+
 ## Running preview builds
 
 You can preview any `.app` artifact built in Codemagic that targets the `iPhoneSimulator`. For such artifacts, there is a **Quick Launch** button available next to the artifact name on the build overview page.

--- a/content/partials/app-preview-builds.md
+++ b/content/partials/app-preview-builds.md
@@ -9,7 +9,7 @@ Note that this feature is available for **teams** on request. Please [contact us
 
 ## Using Workflow Editor to create iOS .app binaries for testing
 
-In the 'Build' section of the Workflow Editor set the 'Mode' to debug. In the 'Build arguments' add `--simulator` next to the iOS '--debug' section.
+In the 'Build' section of the Workflow Editor, set the 'Mode' to debug. In the 'Build arguments' field, add `--simulator` next to the iOS '--debug' section.
 
 ## Creating iOS .app binaries for testing with codemagic.yaml
 

--- a/content/partials/app-preview-builds.md
+++ b/content/partials/app-preview-builds.md
@@ -17,7 +17,7 @@ To create a `.app` to run on the iOS simulator, consult the **codemagic.yaml** s
 
 You should make sure that the following values in the `-destination` string correspond with the macOS instance you are using:
 
-- `name` corresponds with the one of the devices available on the macOS instance being used.
+- `name` corresponds with one of the devices available on the macOS instance being used.
 - `OS` matches the iOS runtime available on the macOS instance being used.
 
 You can find the macOS specifications that list the available iOS devices and runtimes [here](https://docs.codemagic.io/specs-macos/xcode-16-2/#:~:text=Software%20and%20hardware-,macOS%20machines,-Xcode%2016.2.x).

--- a/content/partials/app-preview-builds.md
+++ b/content/partials/app-preview-builds.md
@@ -21,7 +21,7 @@ You can find the macOS specifications that list the available iOS devices and ru
 {{< tabpane >}}
 {{< tab header="Flutter" >}}
 {{<markdown>}}
-Sample **codemagic.yaml** for build an iOS `.app` binary for Flutter projects.
+Sample **codemagic.yaml** for building an iOS `.app` binary for Flutter projects.
 
 {{< highlight yaml "style=paraiso-dark">}}
 workflows:


### PR DESCRIPTION
First codemagic.yaml examples of how to build `.app` for Flutter projects.

Additional Framework samples to be added later.