### PR TITLE
Add missing environment block

### DIFF
--- a/content/yaml-publishing/google-cloud-storage.md
+++ b/content/yaml-publishing/google-cloud-storage.md
@@ -35,6 +35,9 @@ In order to publish your generated artifacts to Google Cloud Storage:
 
 {{< highlight yaml "style=paraiso-dark">}}
 publishing:
+  environment:
+    groups:
+      - google_credentials
   scripts:
     - name: Publish to Google Cloud
       script: | 


### PR DESCRIPTION
Added environment block with `google_credentials` because that is needed for the `GCLOUD_STORAGE_KEY` environment var to become available in the publish script