### PR TITLE
versions newer than `6000.0.37f1` are automaticaly available

### DIFF
--- a/content/knowledge-others/install-unity-version.md
+++ b/content/knowledge-others/install-unity-version.md
@@ -23,6 +23,9 @@ This will automatically install the specified Unity version to the build machine
 
 **The available Unity versions are the following:**
 {{< tabpane >}}
+{{% tab header="v6000" %}}
+- versions newer than `6000.0.37f1` are automaticaly available
+{{< /tab >}}
 {{% tab header="2023.X" %}}
 - `2023.1.10f1`
 - `2023.1.17f1`


### PR DESCRIPTION
Since the new v6000 versions will be automatically available, there's no need to list all the available v6000 versions in docs.
https://nevercode.slack.com/archives/C0JD5UCQL/p1741353138309109

![image](https://github.com/user-attachments/assets/a9c79a53-d65e-42d5-aa05-e46ad2a51f5f)
