### PR TITLE
Monthly CodePush pricing

### DIFF
--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -8,8 +8,7 @@ weight: 2
 
 CodePush (Over-the-Air updates) for React Native projects is priced as follows: 
 - **Free** for annual plans and Enterprise plan customers.
-- **$99/month per team** for Pay-as-you-go plan customers using Codemagic for CI/CD.
-- **$3k/year per team** to integrate CodePush into your existing CI pipeline without a requirement for migration to Codemagic for CI/CD.
+- **$3k/year per team**.
 - **$6k/year** for a dedicated, standalone CodePush instance.
 
 ## Pricing for Individuals

--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -8,7 +8,7 @@ weight: 2
 
 CodePush (Over-the-Air updates) for React Native projects is priced as follows: 
 - **Free** for annual plans and Enterprise plan customers.
-- **$3k/year per team**.
+- **$3k/year per team** with the option to integrate CodePush into your existing CI pipeline without a requirement for migration to Codemagic for CI/CD.
 - **$6k/year** for a dedicated, standalone CodePush instance.
 
 ## Pricing for Individuals


### PR DESCRIPTION
Removing $99/month pricing option