### PR TITLE
Add ubuntu image types docs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -193,6 +193,11 @@ menu:
           parent: specs
           weight: 1
 
+        - identifier: specs-linux
+          name: Linux machines
+          parent: specs
+          weight: 2
+
         - identifier: custom-menu-position
           params:
               hide: true

--- a/content/specs-linux/ubuntu-20.04.md
+++ b/content/specs-linux/ubuntu-20.04.md
@@ -1,9 +1,9 @@
 ---
-description: A list of tools available out-of-the-box on Codemagic Linux build machines.
-title: Linux machines
+description: A list of tools available out-of-the-box on Codemagic Linux Ubuntu 20.04
+title: Ubuntu 20.04 (default)
 aliases:
-  - "../releases-and-versions/versions-linux"
-weight: 2
+  - /specs/versions-linux/
+weight: 3
 ---
 
 ## Hardware

--- a/content/specs-linux/ubuntu-20.04.md
+++ b/content/specs-linux/ubuntu-20.04.md
@@ -3,7 +3,7 @@ description: A list of tools available out-of-the-box on Codemagic Linux Ubuntu 
 title: Ubuntu 20.04 (default)
 aliases:
   - /specs/versions-linux/
-weight: 3
+weight: 2
 ---
 
 ## Hardware

--- a/content/specs-linux/ubuntu-24.04.md
+++ b/content/specs-linux/ubuntu-24.04.md
@@ -5,9 +5,6 @@ aliases:
 weight: 4
 ---
 
-
-# TODO: Review all information and set it properly with new image characteristics
-
 ## Hardware
 
 - Linux virtual machine: `8 vCPUs, 32 GB memory`
@@ -15,8 +12,8 @@ weight: 4
 ## System
 
 - System version `Ubuntu 24.04.2 LTS`
-- Kernel version `TBD`
-- Disk `XXGB (Free Space: XXGB)`
+- Kernel version `6.8.0-1021-gcp`
+- Disk `97GB (Free Space: 63GB)`
 
 
 
@@ -28,63 +25,78 @@ weight: 4
   - Device: `pixel_4 (Google)`
   - Path: `/home/builder/.android/avd/emulator.avd`
   - Target: `Google Play (Google Inc.)`
-  - Based on: `Android 11.0 (R)`
+  - Based on: `Android 14.0 (API level 34)`
   - Tag/API: `google_apis_playstore/x86`
   - Skin: `pixel_4`
   - Sdcard: `512M`
 
-- **emulator-34**
+- **emulator-35**
 
   - Device: `pixel_4 (Google)`
-  - Path: `/home/builder/.android/avd/emulator-34.avd`
+  - Path: `/home/builder/.android/avd/emulator-35.avd`
   - Target: `Google Play (Google Inc.)`
-  - Based on: `Android 14 (API level 34)`
+  - Based on: `Android 15 (API level 35)`
   - Tag/API: `google_apis_playstore/x86`
   - Skin: `pixel_4`
   - Sdcard: `512M`
 
-## Android Studio 2022.3
+- **emulator-36**
+
+  - Device: `pixel_6a (Google)`
+  - Path: `/home/builder/.android/avd/emulator-36.avd`
+  - Target: `Google Play (Google Inc.)`
+  - Based on: `Android 16 (API level 36)`
+  - Tag/API: `google_apis_playstore/x86`
+  - Skin: `pixel_6a`
+  - Sdcard: `512M`
+
+
+## Android Studio 2024.3.1.13
 
 Android Studio path: `~/programs/android-studio`
 
 ## Java versions
 
-- **21.0.1** JAVA_HOME: `/usr/lib/jvm/java-1.21.0-openjdk-amd64`
+- **21.0.1** `/usr/lib/jvm/java-1.21.0-openjdk-amd64`
 - **17.0.11** (default) JAVA_HOME: `/usr/lib/jvm/java-1.17.0-openjdk-amd64`
-- **15.0.3** JAVA_HOME: `/usr/lib/jvm/java-1.15.0-openjdk-amd64`
-- **11.0.20.1** JAVA_HOME: `/usr/lib/jvm/java-1.11.0-openjdk-amd64`
-- **1.8.0_382** JAVA_HOME: `/usr/lib/jvm/java-1.8.0-openjdk-amd64`
+- **11.0.20.1** `/usr/lib/jvm/java-1.11.0-openjdk-amd64`
+- **1.8.0_382** `/usr/lib/jvm/java-1.8.0-openjdk-amd64`
+
+## Gradle versions
+
+- **8.13** `/home/builder/programs/gradle-8.13` 
+- **8.11.1** (default) `/home/builder/programs/gradle-8.11.1`
+- **8.1.1** `/home/builder/programs/gradle-8.1.1`
+- **7.6** `/home/builder/programs/gradle-7.6`
 
 ## Other pre-installed tools
 
 - Android tools `/usr/local/share/android-sdk`
 - Android NDK `25.2.9519653`
-- aws `2.8.9`
-- curl `7.68.0`
-- docker `24.0.2`
-- ew-cli `0.9.17`
-- fastlane `2.214.0`
-- firebase `11.21.0`
-- gem `3.1.4`
-- gh `1.8.1`
-- git `2.25.1`
-- Google Cloud SDK `435.0.1`
-- gradle `8.1.1`
-- gsutil `5.24`
-- ionic `5.4.16`
-- jq `jq-1.6`
-- ktlint `0.43.2`
-- node `20.11.1`
-- npm `10.2.4`
-- python2 `2.7.18`
-- python `3.8.10`
-- ruby `2.7.2p137`
-- ssh
-- snapcraft `7.4.3`
+- aws `2.24.26`
+- curl `8.5.0`
+- docker `28.0.1`
+- ew-cli `0.11.1`
+- fastlane `2.226.0`
+- firebase `13.34.0`
+- gem `3.3.7`
+- gh `2.45.0`
+- git `2.43.0`
+- Google Cloud SDK `514.0.0`
+- gsutil `5.33`
+- ionic `7.2.0`
+- jq `jq-1.7`
+- ktlint `1.5.0`
+- node `20.18.3`
+- npm `11.2.0`
+- python `3.12.5`
+- ruby `3.4.2`
+- OpenSSH `9.6p1`
+- snapcraft `8.7.2`
 - sudo
 - tar / bsdtar
 - unzip
 - wget
-- yarn `1.22.19`
-- yq `4.34.1`
+- yarn `4.7.0`
+- yq `4.44.5
 - zip

--- a/content/specs-linux/ubuntu-24.04.md
+++ b/content/specs-linux/ubuntu-24.04.md
@@ -57,10 +57,10 @@ Android Studio path: `~/programs/android-studio`
 
 ## Java versions
 
-- **21.0.1** `/usr/lib/jvm/java-1.21.0-openjdk-amd64`
-- **17.0.11** (default) JAVA_HOME: `/usr/lib/jvm/java-1.17.0-openjdk-amd64`
-- **11.0.20.1** `/usr/lib/jvm/java-1.11.0-openjdk-amd64`
-- **1.8.0_382** `/usr/lib/jvm/java-1.8.0-openjdk-amd64`
+- **21.0.6** `/usr/lib/jvm/java-1.21.0-openjdk-amd64`
+- **17.0.14** (default) JAVA_HOME: `/usr/lib/jvm/java-1.17.0-openjdk-amd64`
+- **11.0.26** `/usr/lib/jvm/java-1.11.0-openjdk-amd64`
+- **1.8.0_442** `/usr/lib/jvm/java-1.8.0-openjdk-amd64`
 
 ## Gradle versions
 
@@ -80,10 +80,10 @@ Android Studio path: `~/programs/android-studio`
 - ew-cli `0.11.1`
 - fastlane `2.226.0`
 - firebase `13.34.0`
-- gem `3.4.2`
+- gem `3.6.2`
 - gh `2.45.0`
 - git `2.43.0`
-- Google Cloud SDK `516.0.0`
+- Google Cloud SDK `514.0.0`
 - gsutil `5.33`
 - ionic `7.2.0`
 - jq `jq-1.7`

--- a/content/specs-linux/ubuntu-24.04.md
+++ b/content/specs-linux/ubuntu-24.04.md
@@ -12,8 +12,8 @@ weight: 4
 ## System
 
 - System version `Ubuntu 24.04.2 LTS`
-- Kernel version `6.8.0-1021-gcp`
-- Disk `97GB (Free Space: 63GB)`
+- Kernel version `6.8.0-1026-gcp`
+- Disk `150GB (Free Space: 86GB)`
 
 
 
@@ -68,35 +68,37 @@ Android Studio path: `~/programs/android-studio`
 - **8.11.1** (default) `/home/builder/programs/gradle-8.11.1`
 - **8.1.1** `/home/builder/programs/gradle-8.1.1`
 - **7.6** `/home/builder/programs/gradle-7.6`
+- **7.3.1** `/home/builder/programs/gradle-7.3.1`
 
 ## Other pre-installed tools
 
 - Android tools `/usr/local/share/android-sdk`
-- Android NDK `25.2.9519653`
-- aws `2.24.26`
+- Android NDK `22.0.7026061` `25.2.9519653`
+- aws `2.25.7`
 - curl `8.5.0`
 - docker `28.0.1`
 - ew-cli `0.11.1`
 - fastlane `2.226.0`
 - firebase `13.34.0`
-- gem `3.3.7`
+- gem `3.4.2`
 - gh `2.45.0`
 - git `2.43.0`
-- Google Cloud SDK `514.0.0`
+- Google Cloud SDK `516.0.0`
 - gsutil `5.33`
 - ionic `7.2.0`
 - jq `jq-1.7`
 - ktlint `1.5.0`
-- node `20.18.3`
+- node `22.14.1`
 - npm `11.2.0`
 - python `3.12.5`
 - ruby `3.4.2`
 - OpenSSH `9.6p1`
-- snapcraft `8.7.2`
+- snapcraft `8.7.3`
 - sudo
 - tar / bsdtar
 - unzip
 - wget
 - yarn `4.7.0`
-- yq `4.44.5
+- yq `4.44.5`
 - zip
+

--- a/content/specs-linux/ubuntu-24.04.md
+++ b/content/specs-linux/ubuntu-24.04.md
@@ -1,0 +1,90 @@
+---
+description: A list of tools available out-of-the-box on Codemagic Linux Ubuntu 24.04
+title: Ubuntu 24.04
+aliases:
+weight: 4
+---
+
+
+# TODO: Review all information and set it properly with new image characteristics
+
+## Hardware
+
+- Linux virtual machine: `8 vCPUs, 32 GB memory`
+
+## System
+
+- System version `Ubuntu 24.04.2 LTS`
+- Kernel version `TBD`
+- Disk `XXGB (Free Space: XXGB)`
+
+
+
+
+## Android emulators
+
+- **emulator**
+
+  - Device: `pixel_4 (Google)`
+  - Path: `/home/builder/.android/avd/emulator.avd`
+  - Target: `Google Play (Google Inc.)`
+  - Based on: `Android 11.0 (R)`
+  - Tag/API: `google_apis_playstore/x86`
+  - Skin: `pixel_4`
+  - Sdcard: `512M`
+
+- **emulator-34**
+
+  - Device: `pixel_4 (Google)`
+  - Path: `/home/builder/.android/avd/emulator-34.avd`
+  - Target: `Google Play (Google Inc.)`
+  - Based on: `Android 14 (API level 34)`
+  - Tag/API: `google_apis_playstore/x86`
+  - Skin: `pixel_4`
+  - Sdcard: `512M`
+
+## Android Studio 2022.3
+
+Android Studio path: `~/programs/android-studio`
+
+## Java versions
+
+- **21.0.1** JAVA_HOME: `/usr/lib/jvm/java-1.21.0-openjdk-amd64`
+- **17.0.11** (default) JAVA_HOME: `/usr/lib/jvm/java-1.17.0-openjdk-amd64`
+- **15.0.3** JAVA_HOME: `/usr/lib/jvm/java-1.15.0-openjdk-amd64`
+- **11.0.20.1** JAVA_HOME: `/usr/lib/jvm/java-1.11.0-openjdk-amd64`
+- **1.8.0_382** JAVA_HOME: `/usr/lib/jvm/java-1.8.0-openjdk-amd64`
+
+## Other pre-installed tools
+
+- Android tools `/usr/local/share/android-sdk`
+- Android NDK `25.2.9519653`
+- aws `2.8.9`
+- curl `7.68.0`
+- docker `24.0.2`
+- ew-cli `0.9.17`
+- fastlane `2.214.0`
+- firebase `11.21.0`
+- gem `3.1.4`
+- gh `1.8.1`
+- git `2.25.1`
+- Google Cloud SDK `435.0.1`
+- gradle `8.1.1`
+- gsutil `5.24`
+- ionic `5.4.16`
+- jq `jq-1.6`
+- ktlint `0.43.2`
+- node `20.11.1`
+- npm `10.2.4`
+- python2 `2.7.18`
+- python `3.8.10`
+- ruby `2.7.2p137`
+- ssh
+- snapcraft `7.4.3`
+- sudo
+- tar / bsdtar
+- unzip
+- wget
+- yarn `1.22.19`
+- yq `4.34.1`
+- zip

--- a/content/specs-linux/ubuntu-24.04.md
+++ b/content/specs-linux/ubuntu-24.04.md
@@ -2,7 +2,7 @@
 description: A list of tools available out-of-the-box on Codemagic Linux Ubuntu 24.04
 title: Ubuntu 24.04
 aliases:
-weight: 4
+weight: 1
 ---
 
 ## Hardware

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -267,12 +267,13 @@ environment:
 
 #### Build machine and software versions
 
-The snippet below shows how to specify the versions of Flutter, Xcode, CocoaPods, Node, npm, ndk, Java and Ruby used in the build.
+The snippet below shows how to specify the versions of Flutter, Xcode, Ubuntu, CocoaPods, Node, npm, ndk, Java and Ruby used in the build.
 
 {{< highlight yaml "style=paraiso-dark">}}
 environment:
   flutter: stable   # Define the channel name, version (e.g. v1.13.4), or fvm for Flutter Version Management
   xcode: latest     # Define latest, edge or version (e.g. 11.2)
+  ubuntu: 20.04     # Define the OS version for linux_x2 instance type (Available options: 20.04, 24.04)
   cocoapods: 1.9.1  # Define default or version
   node: 12.14.0     # Define default, latest, current, lts, carbon (or another stream), nightly or version
   npm: 6.13.7       # Define default, latest, next, lts or version

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -273,7 +273,7 @@ The snippet below shows how to specify the versions of Flutter, Xcode, Ubuntu, C
 environment:
   flutter: stable   # Define the channel name, version (e.g. v1.13.4), or fvm for Flutter Version Management
   xcode: latest     # Define latest, edge or version (e.g. 11.2)
-  ubuntu: 20.04     # Define the OS version for linux_x2 instance type (Available options: 20.04, 24.04)
+  ubuntu: 20.04     # Define the OS version for linux_x2 instance type (available options are 20.04, 24.04)
   cocoapods: 1.9.1  # Define default or version
   node: 12.14.0     # Define default, latest, current, lts, carbon (or another stream), nightly or version
   npm: 6.13.7       # Define default, latest, next, lts or version

--- a/content/yaml-basic-configuration/yaml-getting-started.md
+++ b/content/yaml-basic-configuration/yaml-getting-started.md
@@ -273,7 +273,7 @@ The snippet below shows how to specify the versions of Flutter, Xcode, Ubuntu, C
 environment:
   flutter: stable   # Define the channel name, version (e.g. v1.13.4), or fvm for Flutter Version Management
   xcode: latest     # Define latest, edge or version (e.g. 11.2)
-  ubuntu: 20.04     # Define the OS version for linux_x2 instance type (available options are 20.04, 24.04)
+  ubuntu: 24.04     # Define the OS version for linux_x2 instance type (available options are 20.04, 24.04)
   cocoapods: 1.9.1  # Define default or version
   node: 12.14.0     # Define default, latest, current, lts, carbon (or another stream), nightly or version
   npm: 6.13.7       # Define default, latest, next, lts or version


### PR DESCRIPTION
- Replaced  `Linux machines` page with a section that holds all available images 

![image](https://github.com/user-attachments/assets/60d49027-6c52-4751-bbfa-19288cd3b22f)

- Mark current linux image as default
- Added "ubuntu" to software versions inside Environment options
