### PR TITLE
Google play credential rename

### DIFF
--- a/content/flutter-configuration/env-variables.md
+++ b/content/flutter-configuration/env-variables.md
@@ -101,7 +101,7 @@ CM_KEYSTORE | contents of keystore - [`base64 encoded`](#storing-binary-files) |
 CM_KEYSTORE_PASSWORD | Put your keystore password here | keystore_credentials
 CM_KEY_PASSWORD | Put your key alias password here | keystore_credentials
 CM_KEY_ALIAS | Put your key alias here | keystore_credentials
-GCLOUD_SERVICE_ACCOUNT_CREDENTIALS | Put your Google Play service account credentials here | google_play_credentials
+GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS | Put your Google Play service account credentials here | google_play_credentials
 GOOGLE_PLAY_TRACK | Any default or custom track that is not in ‘draft’ status | google_play_credentials
 PACKAGE_NAME | Put your package name here | other
 

--- a/content/knowledge-codemagic/build-inputs.md
+++ b/content/knowledge-codemagic/build-inputs.md
@@ -189,7 +189,7 @@ workflows:
       - flutter build apk --build-number="${{ inputs.buildNumber }}" --release
     publishing:
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         in_app_update_priority: ${{ inputs.googlePlayInAppUpdatePriority }}
         release_promotion:
           track: alpha

--- a/content/knowledge-codemagic/build-versioning.md
+++ b/content/knowledge-codemagic/build-versioning.md
@@ -216,7 +216,7 @@ Alternatively, if you use `YAML` configuration, you may just export the value to
 
 Use [`google-play get-latest-build-number`](https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/google-play/get-latest-build-number.md#get-latest-build-number) action from Codemagic CLI tools to get the latest build number from Google Play Console.
 
-In order to do that, you need to provide Google Play API access credentials by providing `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS` as arguments to the action, as defined below.
+In order to do that, you need to provide Google Play API access credentials by providing `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS` as arguments to the action, as defined below.
 
 Additionally, you will need to provide the package name of the app in Google Play Console (Ex. `com.example.app`).
 
@@ -232,7 +232,7 @@ You will need to set up a service account in Google Play Console and create a JS
 {{< tab header="codemagic.yaml" >}}
 {{<markdown>}}
 1. Open your Codemagic app settings, and go to the **Environment variables** tab.
-2. Enter the `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS` as **_Variable name_**.
+2. Enter the `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS` as **_Variable name_**.
 3. Copy and paste the credentials content as **_Variable value_**.
 4. Enter the variable group name, e.g. **_google_play_credentials_**. Click the button to create the group.
 5. Make sure the **Secure** option is selected.
@@ -250,7 +250,7 @@ You will need to set up a service account in Google Play Console and create a JS
 
 {{% tab header="Flutter workflow editor"%}}
 
-Add the `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS` environment variable to your Flutter project in **App settings > Environment variables** (See the details [here](../flutter-configuration/env-variables)).
+Add the `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS` environment variable to your Flutter project in **App settings > Environment variables** (See the details [here](../flutter-configuration/env-variables)).
 {{% /tab %}}
 {{< /tabpane >}}
 
@@ -320,7 +320,7 @@ scripts:
 
 #### Get the build number in the Flutter workflow editor
 
-Provided you have exported your Google Play Console service account credentials as an environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`, you can call it immediately as a build argument to your Android build command to increment the build number:
+Provided you have exported your Google Play Console service account credentials as an environment variable `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`, you can call it immediately as a build argument to your Android build command to increment the build number:
 
 {{< highlight bash "style=paraiso-dark">}}
 --build-number=$(($(google-play get-latest-build-number --package-name 'com.example.app') + 1))

--- a/content/knowledge-codemagic/flutter-screenshots-stores.md
+++ b/content/knowledge-codemagic/flutter-screenshots-stores.md
@@ -288,10 +288,10 @@ Now you can add the following in your `.gitignore` file, at the root of your Flu
 
 Since the `google-play-store.json` and the `app_store_connect.json` files are not meant to be added to your repository, we need to provide them in the workflow in a safe way.
 
-With Codemagic, you can for example store the content of the `google-play-store.json` file in a encrypted environment variable named `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`, and run a script in your workflow that will generate the `google-play-store.json` in the right location, with the right content, by doing as follow:
+With Codemagic, you can for example store the content of the `google-play-store.json` file in a encrypted environment variable named `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`, and run a script in your workflow that will generate the `google-play-store.json` in the right location, with the right content, by doing as follow:
 
 {{< highlight bash "style=paraiso-dark">}}
-echo $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS > android/google-play-store.json
+echo $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS > android/google-play-store.json
 {{< /highlight >}}
 
 Then in your workflow, you can write a script that copies the generated illustrations in the right directories. For example, here is how you can copy your illustrations for the French Android version of your app:

--- a/content/knowledge-others/install-unity-version.md
+++ b/content/knowledge-others/install-unity-version.md
@@ -201,7 +201,7 @@ workflows:
         groups:
           # Add the group environment variables in Codemagic UI (in Application or Team variables) - https://docs.codemagic.io/variables/environment-variable-groups/
           - unity # <-- (Includes UNITY_HOME, UNITY_SERIAL, UNITY_EMAIL and UNITY_PASSWORD)
-          - google_play # <-- (Includes GCLOUD_SERVICE_ACCOUNT_CREDENTIALS <-- Put your google-services.json)
+          - google_play # <-- (Includes GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS <-- Put your google-services.json)
         vars:
           UNITY_VERSION: 2019.4.38f1
           UNITY_VERSION_CHANGESET: fdbb7325fa47

--- a/content/partials/environment-variable-groups.md
+++ b/content/partials/environment-variable-groups.md
@@ -97,7 +97,7 @@ CM_KEYSTORE | contents of keystore - [`base64 encoded`](../variables/environment
 CM_KEYSTORE_PASSWORD | Put your keystore password here | keystore_credentials
 CM_KEY_PASSWORD | Put your key alias password here | keystore_credentials
 CM_KEY_ALIAS | Put your key alias here | keystore_credentials
-GCLOUD_SERVICE_ACCOUNT_CREDENTIALS | Put your Google Play service account credentials here | google_play_credentials
+GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS | Put your Google Play service account credentials here | google_play_credentials
 GOOGLE_PLAY_TRACK | Any default or custom track that is not in ‘draft’ status | google_play_credentials
 PACKAGE_NAME | Put your package name here | other
 

--- a/content/partials/migrating-from-bitrise.md
+++ b/content/partials/migrating-from-bitrise.md
@@ -199,7 +199,7 @@ To deploy to Google Play, a service account is required. Creating a service acco
 
 If you have already uploaded your service account to Bitrise, you can download it from there under `Generic file storage`. Alternatively, you can set up a new service account following the instructions [here](../knowledge-base/google-services-authentication/).
 
-To add your service account to your configuration file, add it as an environment variable. For example, `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. First, navigate to your application and click the `Environment variables` tab. To add the file, encode its contents with base64 and paste the value into Codemagic; make sure to check `Secure` when providing sensitive information. You can either add it to an already created group or create a new group, which you can later reference in your `codemagic.yaml`.
+To add your service account to your configuration file, add it as an environment variable. For example, `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`. First, navigate to your application and click the `Environment variables` tab. To add the file, encode its contents with base64 and paste the value into Codemagic; make sure to check `Secure` when providing sensitive information. You can either add it to an already created group or create a new group, which you can later reference in your `codemagic.yaml`.
 
 Like Bitrise's `Google Play Deploy` step, Codemagic allows you to modify the track, rollout fraction, and update priority. In addition, you can conveniently configure to submit the build as a draft or choose not the send the changes directly to review.
 
@@ -226,7 +226,7 @@ The `Google Play Deploy` step in `bitrise.yml` and the publishing in `codemagic.
 ```yaml
 publishing:
   google_play:
-    credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS 
+    credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS 
     track: alpha 
     in_app_update_priority: 3
     rollout_fraction: 0.25

--- a/content/partials/quickstart/build-versioning-android.md
+++ b/content/partials/quickstart/build-versioning-android.md
@@ -8,7 +8,7 @@ The prerequisite is a valid **Google Cloud Service Account**. Please follow thes
 1. Go to [this guide](https://docs.codemagic.io/yaml-publishing/google-play/) and complete the steps in the **Google Play** section.
 2. Skip to the **Creating a service account** section in the same guide and complete those steps also.
 3. You now have a `JSON` file with the credentials.
-4. Open Codemagic UI and create a new Environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`.
+4. Open Codemagic UI and create a new Environment variable `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`.
 5. Paste the content of the downloaded `JSON` file in the **_Value_** field, set the group name (e.g. **google_play**) and make sure the **Secure** option is checked.
 ---
 6. Add the **google_play** variable group to the `codemagic.yaml`

--- a/content/partials/quickstart/build-versioning-kmm-android.md
+++ b/content/partials/quickstart/build-versioning-kmm-android.md
@@ -8,7 +8,7 @@ The prerequisite is a valid **Google Cloud Service Account**. Please follow thes
 1. Go to [this guide](https://docs.codemagic.io/yaml-publishing/google-play/) and complete the steps in the **Google Play** section.
 2. Skip to the **Creating a service account** section in the same guide and complete those steps also.
 3. You now have a `JSON` file with the credentials.
-4. Open Codemagic UI and create a new Environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`.
+4. Open Codemagic UI and create a new Environment variable `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`.
 5. Paste the content of the downloaded `JSON` file in the **_Value_** field, set the group name (e.g. **google_play**) and make sure the **Secure** option is checked.
 ---
 6. Add the **google_play** variable group to the `codemagic.yaml`

--- a/content/partials/quickstart/publishing-google-play.md
+++ b/content/partials/quickstart/publishing-google-play.md
@@ -10,7 +10,7 @@ react-native-android:
   publishing:
     # ...
     google_play:
-      credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+      credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
       track: internal
       submit_as_draft: true
 {{< /highlight >}}

--- a/content/troubleshooting/common-google-play-errors.md
+++ b/content/troubleshooting/common-google-play-errors.md
@@ -76,7 +76,7 @@ This could be due to an invalid JSON file or permission issues with the service 
   {{< highlight yaml "style=paraiso-dark">}}
 publishing:
   google_play:
-    credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+    credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
     track: internal
     # Optional boolean To be used ONLY if your app cannot be sent for review automatically
     changes_not_sent_for_review: true

--- a/content/yaml-basic-configuration/configuring-environment-variables.md
+++ b/content/yaml-basic-configuration/configuring-environment-variables.md
@@ -173,7 +173,7 @@ CM_KEYSTORE | contents of keystore - [`base64 encoded`](#storing-binary-files) |
 CM_KEYSTORE_PASSWORD | Put your keystore password here | keystore_credentials
 CM_KEY_PASSWORD | Put your key alias password here | keystore_credentials
 CM_KEY_ALIAS | Put your key alias here | keystore_credentials
-GCLOUD_SERVICE_ACCOUNT_CREDENTIALS | Put your Google Play service account credentials here | google_play_credentials
+GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS | Put your Google Play service account credentials here | google_play_credentials
 GOOGLE_PLAY_TRACK | Any default or custom track that is not in ‘draft’ status | google_play_credentials
 PACKAGE_NAME | Put your package name here | other
 

--- a/content/yaml-publishing/google-play.md
+++ b/content/yaml-publishing/google-play.md
@@ -61,7 +61,7 @@ Once you make all the preparations as described above and configure publishing t
 1. Save the contents of the `JSON` key file as a [secure environment variable](../variables/environment-variable-groups/#storing-sensitive-valuesfiles) in application or team settings:
 
    1. Open your Codemagic app settings, and go to the **Environment variables** tab.
-   2. Enter the desired **_Variable name_**, e.g. `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`.
+   2. Enter the desired **_Variable name_**, e.g. `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`.
    3. Copy and paste the key file content as **_Variable value_**.
    4. Enter the variable group name, e.g. **_google_credentials_**. Click the button to create the group.
    5. Make sure the **Secure** option is selected.
@@ -81,7 +81,7 @@ publishing:
   google_play: 
     # Contents of the JSON key file for Google Play service account saved 
     # as a secure environment variable
-    credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+    credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
 
     # Name of the track internal, alpha, beta, production, internal app sharing,
     # or your custom track name

--- a/content/yaml-quick-start/building-a-cordova-app.md
+++ b/content/yaml-quick-start/building-a-cordova-app.md
@@ -208,7 +208,7 @@ workflows:
           success: true
           failure: false
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: internal
         submit_as_draft: true
 {{< /highlight >}}

--- a/content/yaml-quick-start/building-a-dotnet-maui-app.md
+++ b/content/yaml-quick-start/building-a-dotnet-maui-app.md
@@ -391,7 +391,7 @@ workflows:
         - /Users/builder/clone/artifacts/*Signed.aab
     publishing:
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: internal
         submit_as_draft: true
 {{< /highlight >}}

--- a/content/yaml-quick-start/building-a-flutter-app.md
+++ b/content/yaml-quick-start/building-a-flutter-app.md
@@ -364,7 +364,7 @@ You can find the full sample project with the instructions on alternative ways t
 The prerequisite is a valid **Google Cloud Service Account**. Please follow these steps:
 1. Go to [this link](https://docs.codemagic.io/yaml-publishing/google-play/#configure-google-play-api-access) and complete the steps.
 2. You now have a `JSON` file with the credentials.
-3. Open Codemagic UI and create a new Environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`.
+3. Open Codemagic UI and create a new Environment variable `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`.
 4. Paste the content of the downloaded `JSON` file in the **_Value_** field, set the group name (e.g. **google_play**) and make sure the **Secure** option is checked.
 5. Add the **google_play** variable group to the `codemagic.yaml` as well as define the `PACKAGE_NAME` and the `GOOGLE_PLAY_TRACK`:
 {{< highlight yaml "style=paraiso-dark">}}
@@ -485,7 +485,7 @@ workflows:
           success: true
           failure: false
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: $GOOGLE_PLAY_TRACK
         submit_as_draft: true
 {{< /highlight >}}

--- a/content/yaml-quick-start/building-a-kmm-app.md
+++ b/content/yaml-quick-start/building-a-kmm-app.md
@@ -144,7 +144,7 @@ workflows:
           success: true
           failure: false
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: internal
         submit_as_draft: true
 {{< /highlight >}}

--- a/content/yaml-quick-start/building-a-native-android-app.md
+++ b/content/yaml-quick-start/building-a-native-android-app.md
@@ -121,7 +121,7 @@ workflows:
           success: true
           failure: false
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: internal
         submit_as_draft: true
 {{< /highlight >}}

--- a/content/yaml-quick-start/building-a-react-native-app.md
+++ b/content/yaml-quick-start/building-a-react-native-app.md
@@ -329,7 +329,7 @@ workflows:
           success: true
           failure: false
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: internal
         submit_as_draft: true
 

--- a/content/yaml-quick-start/building-a-unity-app.md
+++ b/content/yaml-quick-start/building-a-unity-app.md
@@ -441,7 +441,7 @@ The prerequisite is a valid **Google Cloud Service Account**. Please follow thes
 1. Go to [this guide](../knowledge-base/google-services-authentication) and complete the steps in the **Google Play** section.
 2. Skip to the **Creating a service account** section in the same guide and complete those steps also.
 3. You now have a `JSON` file with the credentials.
-4. Open Codemagic UI and create a new Environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`.
+4. Open Codemagic UI and create a new Environment variable `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`.
 5. Paste the content of the downloaded `JSON` file in the **_Value_** field, set the group name (e.g. **google_play**) and make sure the **Secure** option is checked.
 6. Add the **google_play** variable group to the `codemagic.yaml` as well as define the `PACKAGE_NAME` and the `GOOGLE_PLAY_TRACK`:
 {{< highlight yaml "style=paraiso-dark">}}
@@ -856,7 +856,7 @@ workflows:
           success: true
           failure: false
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: GOOGLE_PLAY_TRACK
         submit_as_draft: true
 {{< /highlight >}}

--- a/content/yaml-quick-start/building-an-ionic-app.md
+++ b/content/yaml-quick-start/building-an-ionic-app.md
@@ -190,7 +190,7 @@ workflows:
           success: true
           failure: false
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: internal
         submit_as_draft: true
 {{< /highlight >}}

--- a/content/yaml-quick-start/migrating-from-app-center.md
+++ b/content/yaml-quick-start/migrating-from-app-center.md
@@ -176,7 +176,7 @@ workflows:
           android_signing:
             - keystore_reference
           groups:
-            - google_play # <-- (Includes GCLOUD_SERVICE_ACCOUNT_CREDENTIALS <-- Put your google-services.json)
+            - google_play # <-- (Includes GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS <-- Put your google-services.json)
           vars:
             PACKAGE_NAME: "io.codemagic.sample.reactnative" # <-- Put your package name here e.g. com.domain.myapp
           node: v19.7.0
@@ -211,7 +211,7 @@ workflows:
               success: true     # To not receive a notification when a build succeeds
               failure: false    # To not receive a notification when a build fails
           google_play:
-            credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+            credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
             track: alpha   # Any default or custom track that is not in ‘draft’ status
 {{< /highlight >}}
 

--- a/content/yaml-quick-start/migrating-from-bitrise.md
+++ b/content/yaml-quick-start/migrating-from-bitrise.md
@@ -171,7 +171,7 @@ To deploy to **Google Play**, a service account is required. Creating a service 
 
 If you have already uploaded your service account to Bitrise, you can download it from there under `Generic file storage`. Alternatively, you can set up a new service account following the instructions [here](../knowledge-base/google-services-authentication/).
 
-To add your service account to your configuration file, add it as an environment variable. For example, `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`. First, navigate to your application and click the `Environment variables` tab. To add the file, encode its contents with base64 and paste the value into Codemagic; make sure to check `Secure` when providing sensitive information. You can either add it to an already created group or create a new group, which you can later reference in your `codemagic.yaml`.
+To add your service account to your configuration file, add it as an environment variable. For example, `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`. First, navigate to your application and click the `Environment variables` tab. To add the file, encode its contents with base64 and paste the value into Codemagic; make sure to check `Secure` when providing sensitive information. You can either add it to an already created group or create a new group, which you can later reference in your `codemagic.yaml`.
 
 Like Bitrise's `Google Play Deploy` step, Codemagic allows you to modify the track, rollout fraction, and update priority. In addition, you can conveniently configure to submit the build as a draft or choose to send the changes directly to review.
 
@@ -199,7 +199,7 @@ The `Google Play Deploy` step in `bitrise.yml` and the publishing in `codemagic.
 {{< highlight yaml "style=paraiso-dark">}}
 publishing:
   google_play:
-    credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS 
+    credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS 
     track: alpha 
     in_app_update_priority: 3
     rollout_fraction: 0.25

--- a/content/yaml-quick-start/white-label-getting-started.md
+++ b/content/yaml-quick-start/white-label-getting-started.md
@@ -47,7 +47,7 @@ You should create a uniquely named environment variable group for each of your c
 This group might contain the following environment variables:
 - Android package name. `PACKAGE_NAME`.
 - Android Keystore information. `CM_KEYSTORE` (base64 encoded), `CM_KEY_ALIAS`, `CM_KEY_PASSWORD`, `CM_KEYSTORE_PASSWORD`, `CM_KEYSTORE_PATH`.
-- The content of the Google Cloud service JSON file to publish to Play Store. `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`, learn how to get it [here](../yaml-publishing/google-play/#configure-google-play-api-access).
+- The content of the Google Cloud service JSON file to publish to Play Store. `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS`, learn how to get it [here](../yaml-publishing/google-play/#configure-google-play-api-access).
 - iOS app details. `APP_STORE_ID`, `BUNDLE_ID`.
 - App Store Connect API key. `APP_STORE_CONNECT_KEY_IDENTIFIER`, `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_PRIVATE_KEY`, learn how to create create a new key [here](../yaml-code-signing/alternative-code-signing-methods/#:~:text=Creating%20the%20App%20Store%20Connect%20API%20key).
 - iOS Distribution certificate private key. `CERTIFICATE_PRIVATE_KEY`, learn how to obtain it [here](../yaml-code-signing/alternative-code-signing-methods/#:~:text=Obtaining%20the%20Certificate%20private%20key).
@@ -253,7 +253,7 @@ Make sure you add each client’s service account JSON key file to their environ
 {{< highlight yaml "style=paraiso-dark">}}
 publishing:
   google_play:
-    credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+    credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
     track: <your-track>
 {{< /highlight >}}
 {{<markdown>}}
@@ -336,7 +336,7 @@ workflows:
       - build/**/outputs/**/*.aab
     publishing:
       google_play:
-        credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
+        credentials: $GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
         track: $GOOGLE_PLAY_TRACK 
 {{< /highlight >}}
 {{< /tab >}}


### PR DESCRIPTION
updated GCLOUD_SERVICE_ACCOUNT_CREDENTIALS to GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS to fix CLI  deprecation warning:

`Warning: Using environment variable GCLOUD_SERVICE_ACCOUNT_CREDENTIALS to define argument value is deprecated and will be removed in a future release. Use environment variable GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS instead.`