### PR TITLE
Correct Python version requirement

### DIFF
--- a/content/knowledge-codemagic/codemagic-cli-tools.md
+++ b/content/knowledge-codemagic/codemagic-cli-tools.md
@@ -17,7 +17,7 @@ For more information, review the full documentation on [CLI tools](https://githu
 
 
 {{<notebox>}}
-**Note:** Requires: Python ≥ 3.7
+**Note:** Requires: Python ≥ 3.8
 {{</notebox>}}
 
 


### PR DESCRIPTION
CLI tools require Python 3.8 as minimum version.