### PR TITLE
App migration from Personal accounts to Teams

### DIFF
--- a/content/getting-started/teams.md
+++ b/content/getting-started/teams.md
@@ -35,7 +35,7 @@ To add new applications to a team, click **Add application** on the Apps page an
 {{<notebox>}}
 **Notes on transferring apps to team:** 
 * Please review the repository settings and team integrations to ensure that your setup is intact and the repository is still accessible after the transfer. Read more about configuring repository access in [team integrations](#managing-team-integrations).
-* Global variables and secrets are not transferred from personal account, so please copy over any environment variables and secrets that your workflows rely on.
+* Global variables and secrets, **including application level iOS and Android code signing configurations**, are not transferred from personal account, so please copy over any environment variables and secrets that your workflows rely on.
 * If you used code signing identities on your personal account, please review any setup related to code signing identities.
 * Once an application has been transferred to a team, it cannot be transferred back to the personal account or to other teams.
 {{</notebox>}}

--- a/content/getting-started/teams.md
+++ b/content/getting-started/teams.md
@@ -35,7 +35,7 @@ To add new applications to a team, click **Add application** on the Apps page an
 {{<notebox>}}
 **Notes on transferring apps to team:** 
 * Please review the repository settings and team integrations to ensure that your setup is intact and the repository is still accessible after the transfer. Read more about configuring repository access in [team integrations](#managing-team-integrations).
-* As Personal account and a team account are two different teams/accounts, iOS and Android code signing configurations are not transferred from personal account, so please re-adjust workflows that rely on these configurations.
+* As Personal accounts and team accounts are two different teams/accounts, iOS and Android code signing configurations are not transferred from personal account, so please re-adjust workflows that rely on these configurations.
 * If you used code signing identities on your personal account, please review any setup related to code signing identities.
 * Once an application has been transferred to a team, it cannot be transferred back to the personal account or to other teams.
 {{</notebox>}}

--- a/content/getting-started/teams.md
+++ b/content/getting-started/teams.md
@@ -35,7 +35,7 @@ To add new applications to a team, click **Add application** on the Apps page an
 {{<notebox>}}
 **Notes on transferring apps to team:** 
 * Please review the repository settings and team integrations to ensure that your setup is intact and the repository is still accessible after the transfer. Read more about configuring repository access in [team integrations](#managing-team-integrations).
-* Global variables and secrets, **including application level iOS and Android code signing configurations**, are not transferred from personal account, so please copy over any environment variables and secrets that your workflows rely on.
+* As Personal account and a team account are two different teams/accounts, iOS and Android code signing configurations are not transferred from personal account, so please re-adjust workflows that rely on these configurations.
 * If you used code signing identities on your personal account, please review any setup related to code signing identities.
 * Once an application has been transferred to a team, it cannot be transferred back to the personal account or to other teams.
 {{</notebox>}}


### PR DESCRIPTION
Highlighting that iOS and Android code signing configurations are not carried over when applications are moved from personal accounts to teams