### PR TITLE
Make the placing of the `cache` section more concrete in `codemagic.yaml`

### DIFF
--- a/content/knowledge-codemagic/caching.md
+++ b/content/knowledge-codemagic/caching.md
@@ -32,13 +32,16 @@ A great article on Unity caching can be found in [our blog](https://blog.codemag
 
 {{< tab header="codemagic.yaml" >}}
 {{<markdown>}}
-To use caching, simply add a `cache` section to your `codemagic.yaml` file and list the paths you would like to cache.
+To use caching, simply add a top-level `cache` section to your `codemagic.yaml` file and list the paths you would like to cache.
 
 {{< highlight yaml "style=paraiso-dark">}}
   cache:
     cache_paths:
       - ~/.gradle/caches
       - ...
+
+  workflows:
+    ...
 {{< /highlight >}}
 {{</markdown>}}
 {{< /tab >}}


### PR DESCRIPTION
If I undersand correctly, the `cache`  section should be added as a top-level section in the `codemagic.yaml` file. If that's the case, I think it would be nice to clarify that.

If it's not the case, then I believe the document should explicitly state that instead.