### PR TITLE
Add the Versions of Unity newly added to the docs

### DIFF
--- a/content/knowledge-others/install-unity-version.md
+++ b/content/knowledge-others/install-unity-version.md
@@ -43,6 +43,7 @@ This will automatically install the specified Unity version to the build machine
 - `2022.3.29f1`
 - `2022.3.30f1`
 - `2022.3.47f1`
+- `2022.3.62f2`
 {{< /tab >}}
 {{% tab header="2021.X" %}}
 - `2021.3.4f1`
@@ -59,6 +60,7 @@ This will automatically install the specified Unity version to the build machine
 - `2021.3.24f1`
 - `2021.3.27f1`
 - `2021.3.28f1`
+- `2021.3.45f2`
 {{< /tab >}}
 {{% tab header="2020.X" %}}
 - `2020.3.15f2`


### PR DESCRIPTION
Unity versions `2022.3.62f2` and `2021.3.45f2` have been [added](https://nevercode.slack.com/archives/CCGU5M8P3/p1759511973146159?thread_ts=1759492293.298399&cid=CCGU5M8P3) as pre-installed but not updated yet in the docs. 