### PR TITLE
crashlytics update

### DIFF
--- a/content/knowledge-firebase/firebase-crashlytics-dsym-uploading.md
+++ b/content/knowledge-firebase/firebase-crashlytics-dsym-uploading.md
@@ -66,6 +66,11 @@ publishing:
       fi
 
 {{< /highlight >}}
+
+{{<notebox>}}
+ **Note:** The sample path uses `Runner.xcarchive` because Flutter iOS projects use `Runner` as the default app target.  
+ If your project was renamed or you manually changed the iOS target name, make sure to update the path accordingly.
+{{</notebox>}}
  
 The above-mentioned **dsymPath** is Flutter specific and it could change depending on what platform the app is built on. For example, in React Native or Native iOS applications you might use the dsymPath as:
 


### PR DESCRIPTION
Updated the dSYM upload script for Firebase Crashlytics to make sure the correct symbol file is always uploaded.
The previous version searched for any *.dSYM, which could unintentionally pick up a framework or dependency dSYM. This sometimes resulted in incorrect symbol uploads.

The new version targets the app’s actual dSYM:

`find $CM_BUILD_DIR/build/ios/archive/Runner.xcarchive/dSYMs -name "Runner.app.dSYM"`

Issue for reference: https://github.com/codemagic-ci-cd/codemagic-docs/issues/2918