### PR TITLE
Unity docs update

### DIFF
--- a/content/knowledge-others/install-unity-version.md
+++ b/content/knowledge-others/install-unity-version.md
@@ -238,7 +238,8 @@ workflows:
       publishing:
         scripts:
           - name: Deactivate Unity License
-            script: $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -returnlicense -nographics
+            script: |
+                $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -logFile - -returnlicense -username ${UNITY_EMAIL} -password ${UNITY_PASSWORD}
 {{< /highlight >}}
 {{< /tab >}}
 {{% tab header="Windows" %}}

--- a/content/yaml-quick-start/building-a-unity-app.md
+++ b/content/yaml-quick-start/building-a-unity-app.md
@@ -156,7 +156,7 @@ To deactivate a Unity license on the build machine, add the following script ste
     scripts:
       - name: Deactivate Unity License
       script: | 
-        $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -returnlicense -nographics
+        $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -logFile - -returnlicense -username ${UNITY_EMAIL} -password ${UNITY_PASSWORD}
 {{< /highlight >}}
 {{< /tab >}}
 
@@ -166,10 +166,7 @@ To deactivate a Unity license on the build machine, add the following script ste
     scripts:
       - name: Deactivate Unity License
         script: | 
-          /Applications/Unity\ Hub.app/Contents/Frameworks/UnityLicensingClient_V1.app/Contents/MacOS/Unity.Licensing.Client \
-            --return-ulf \
-            --username ${UNITY_EMAIL?} \
-            --password ${UNITY_PASSWORD?}
+          $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -logFile - -returnlicense -username ${UNITY_EMAIL} -password ${UNITY_PASSWORD}
 {{< /highlight >}}
 {{% /tab %}}
 
@@ -844,10 +841,7 @@ workflows:
       scripts:
         - name: Deactivate Unity License
           script: | 
-            /Applications/Unity\ Hub.app/Contents/Frameworks/UnityLicensingClient_V1.app/Contents/MacOS/Unity.Licensing.Client \
-            --return-ulf \
-            --username ${UNITY_EMAIL} \
-            --password ${UNITY_PASSWORD}
+            $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -logFile - -returnlicense -username ${UNITY_EMAIL} -password ${UNITY_PASSWORD}
       email:
         recipients:
           - user_1@example.com
@@ -918,10 +912,7 @@ workflows:
       scripts:
         - name: Deactivate Unity License
           script: | 
-            /Applications/Unity\ Hub.app/Contents/Frameworks/UnityLicensingClient_V1.app/Contents/MacOS/Unity.Licensing.Client \
-            --return-ulf \
-            --username ${UNITY_EMAIL} \
-            --password ${UNITY_PASSWORD}
+            $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -logFile - -returnlicense -username ${UNITY_EMAIL} -password ${UNITY_PASSWORD}
       email:
         recipients:
           - user_1@example.com
@@ -1027,10 +1018,7 @@ workflows:
       scripts:
         - name: Deactivate Unity License
           script: | 
-            /Applications/Unity\ Hub.app/Contents/Frameworks/UnityLicensingClient_V1.app/Contents/MacOS/Unity.Licensing.Client \
-            --return-ulf \
-            --username ${UNITY_EMAIL} \
-            --password ${UNITY_PASSWORD}
+            $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -logFile - -returnlicense -username ${UNITY_EMAIL} -password ${UNITY_PASSWORD}
       email:
         recipients:
           - user_1@example.com

--- a/content/yaml-quick-start/building-a-vr-oculus-app.md
+++ b/content/yaml-quick-start/building-a-vr-oculus-app.md
@@ -131,7 +131,7 @@ To deactivate a Unity license on the build machine, add the following script ste
     scripts:
       - name: Deactivate Unity License
       script: | 
-        $UNITY_BIN -batchmode -quit -returnlicense -nographics
+        $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -logFile - -returnlicense -username ${UNITY_EMAIL} -password ${UNITY_PASSWORD}
 {{< /highlight >}}
 {{< /tab >}}
 
@@ -141,10 +141,7 @@ To deactivate a Unity license on the build machine, add the following script ste
     scripts:
       - name: Deactivate Unity License
       script: | 
-        /Applications/Unity\ Hub.app/Contents/Frameworks/UnityLicensingClient_V1.app/Contents/MacOS/Unity.Licensing.Client \
-          --return-ulf \
-          --username ${UNITY_USERNAME?} \
-          --password ${UNITY_PASSWORD?}
+        $UNITY_HOME/Contents/MacOS/Unity -batchmode -quit -logFile - -returnlicense -username ${UNITY_EMAIL} -password ${UNITY_PASSWORD}
 {{< /highlight >}}
 {{% /tab %}}
 


### PR DESCRIPTION
1. Having `-logfile `without a parameter is incorrect, it should be `-logfile -` (with the extra hyphen) [per unity's docs](https://docs.unity3d.com/Manual/embedded-platforms-command-line-arguments.html#:~:text=%2D-,logfile,-%2D). 
The build throws an error otherwise

2. The macOS deactivation CLI tool UnityLicensingClient_V1.app just seems to not work anymore. It doesn't return the license. Instead unity advises to use [this script](https://docs.unity3d.com/6000.2/Documentation/Manual/ManagingYourUnityLicense.html#:~:text=%3Cunity%2Dcommand%2Dlocation%3E%20%2Dquit%20%2Dbatchmode%20%2Dreturnlicense%20%2Dusername%20%27name%40example.com%27%20%2Dpassword%20%27XXXXXXXXXXXXX%27)
`<unity-command-location> -quit -batchmode -returnlicense -username 'name@example.com' -password 'XXXXXXXXXXXXX'`
