### PR TITLE
make Windows image specs nested

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -202,6 +202,11 @@ menu:
           parent: specs
           weight: 2
 
+        - identifier: specs-windows
+          name: Windows machines
+          parent: specs
+          weight: 3
+
         - identifier: custom-menu-position
           params:
               hide: true

--- a/content/specs-windows/windows-2022.md
+++ b/content/specs-windows/windows-2022.md
@@ -1,7 +1,9 @@
 ---
-description: A list of tools available out-of-the-box on Codemagic Windows build machines.
-title: Windows machines
-weight: 3
+description: A list of tools available out-of-the-box on Codemagic Windows 2022 build machines.
+title: Windows 2022
+aliases:
+- /specs/versions-windows/
+weight: 1
 ---
 
 ## Hardware

--- a/content/specs/xcode-update-policy.md
+++ b/content/specs/xcode-update-policy.md
@@ -2,7 +2,7 @@
 description: How we release and deprecate Xcode versions
 title: Xcode update policy
 aliases:
-weight: 4
+weight: 1
 ---
 
 ## Overview


### PR DESCRIPTION
To make it consistent with other images specs, make Windows specs page in a nested menu
<img width="315" height="248" alt="image" src="https://github.com/user-attachments/assets/12ee9158-4b38-48fe-9450-e32e2ee311c6" />
