### PR TITLE
Codepush analytics page adjustment

### DIFF
--- a/content/rn-codepush/codepush-analytics.md
+++ b/content/rn-codepush/codepush-analytics.md
@@ -23,9 +23,7 @@ Each project is listed below with its latest release and per-release download, i
 
 ### CLI
 
-You can view per-release metrics directly in the terminal without leaving your release workflow.
-
-`deployment ls` shows the latest release for each deployment along with its current install metrics:
+You can view per-release metrics directly in the terminal. `deployment ls` shows the latest release for each deployment along with its current install metrics:
 
 | **Metric** | **Description** |
 | --- | --- |

--- a/content/rn-codepush/codepush-analytics.md
+++ b/content/rn-codepush/codepush-analytics.md
@@ -4,39 +4,73 @@ description: Installation and usage metrics for OTA updates
 weight: 8
 ---
 
-Customers using a CodePush server managed by Codemagic get access to analytics about their monthly usage as well as detailed deployment metrics on the OTA Updates page.
+CodePush analytics are available via the dashboard, CLI or API, so you can use the one suitable to your workflow.
 
-These metrics allow developers to:
+## Accessing your metrics
 
-- monitor update adoption
-- detect installation problems
-- evaluate rollout success
-- understand overall OTA usage
+### Dashboard
 
-Analytics are typically visible in the Codemagic **OTA Updates dashboard**.
+The Codemagic OTA Updates dashboard gives a visual overview of your team's OTA activity.
 
-These insights help teams decide when to proceed with a rollout, adjust or halt rollout using the CodePush CLI, or roll back—see [Production control](/rn-codepush/production-control/).
+The main page shows team-level totals for the current month:
 
-## Usage analytics
+- **Downloads** - total update downloads across all projects
+- **Installs** - total successful installs across all projects
 
-The main OTA Updates page gives an overview of your team's OTA usage across all projects (apps), grouped by month.
+It also includes a time-series chart of succeeded and failed installs, updated hourly.
 
-* **Downloads** - the total number of update downloads across all projects in a given month
-* **Installs** - the total number of successful update installs across all projects in a given month
+Each project is listed below with its latest release and per-release download, install, and failure counts. Clicking through to a project shows time-series charts for downloads, installs, and failures broken down by release version, with a configurable date range.
 
-Additionally, the page includes an installation chart showing the daily number of successful and failed installs, helping you understand when end users install updates and identify trends or potential issues.
+### CLI
 
-{{<notebox>}}
-**Note**: Data on the page is updated hourly.
-{{</notebox>}}
+You can view per-release metrics directly in the terminal without leaving your release workflow.
 
-## Projects and release metrics
+`deployment ls` shows the latest release for each deployment along with its current install metrics:
 
-Your projects (apps) on the server are listed in the **Projects** section of the OTA Updates page. 
+| **Metric** | **Description** |
+| --- | --- |
+| Active | Users currently running this release |
+| Total | All successful installs since release |
+| Pending | Downloaded but not yet installed |
+| Rollbacks | Automatic client-side rollbacks |
 
-To view detailed metrics for a specific project and deployment channel, click the **arrow** icon next to the project and select the desired **Deployment channel** at the top of the page. 
+Run the following command to list deployment metrics for an app:
 
-The page then lists all updates to the project for the selected deployment channel and shows the number of downloads, successful installs, and failed installs for each update. You can also select a time period at the top of the page to track adoption trends over time.
+{{< highlight bash "style=paraiso-dark">}}
+code-push deployment ls MyApp-Android
+{{< /highlight >}}
+
+`deployment history` shows the same metrics for all recent releases in a deployment, useful for comparing adoption across versions:
+
+{{< highlight bash "style=paraiso-dark">}}
+code-push deployment history MyApp-Android Production
+{{< /highlight >}}
+
+### API
+
+The [REST API](https://codemagic.io/api/v3/schema#tag/over-the-air-updates/GET/api/v3/ota/deployments/{deployment_id}/releases) provides time-series usage data for integrating CodePush metrics into external dashboards or observability tooling.
+
+Per-deployment metrics are available for a configurable date range:
+
+| **Metric** | **Description** |
+| --- | --- |
+| download_count | Update downloads over the period |
+| deployment_succeeded_count | Successful installs over the period |
+| deployment_failed_count | Failed installs over the period |
+
+{{< highlight bash "style=paraiso-dark">}}
+curl 'https://codemagic.io/api/v3/ota/deployments/{deployment_id}/releases?page_size=30&page=1' \
+  --header 'x-auth-token: YOUR_SECRET_TOKEN'
+{{< /highlight >}}
+
+Team-level usage is also available, aggregating across all projects:
+
+{{< highlight bash "style=paraiso-dark">}}
+curl 'https://codemagic.io/api/v3/ota/{team_id}/usage?period_from=&period_to=' \
+  --header 'x-auth-token: YOUR_SECRET_TOKEN'
+{{< /highlight >}}
+
+See the [REST API reference](/codemagic-rest-api/api-overview/) for the full endpoint list.
 
 ## Deployment health
 

--- a/content/rn-codepush/concepts.md
+++ b/content/rn-codepush/concepts.md
@@ -95,6 +95,11 @@ These updates modify only the JavaScript bundle, so they can be safely delivered
 
  These changes affect compiled native code, so they must go through the App Store or Play Store.
 
+### Delta updates
+
+CodePush uses delta updates (file-level diffs) for each release and delivers only the JavaScript files and assets that changed.
+
+Instead of redownloading a complete bundle and all static assets on every update, users receive a smaller delta package. This keeps OTA updates faster and reduces bandwidth usage.
 
 ## How the update flow works
 

--- a/content/rn-codepush/concepts.md
+++ b/content/rn-codepush/concepts.md
@@ -118,6 +118,21 @@ The update replaces the previously installed JavaScript bundle while keeping the
 
 If an update fails or causes the app to crash on startup before it is marked as successful, the client can automatically revert to the previous working bundle.
 
+### Prerequisite: a native build with the SDK
+
+Because CodePush relies on the client SDK to check the server, download bundles, and swap the JS layer at launch, **the SDK must already be present in the native binary running on each user's device**. A store build that does not include the SDK cannot install OTA updates — `release-react` will still publish the bundle, but no client will pick it up.
+
+The first time you add CodePush to an existing app, you therefore need to:
+
+1. Integrate the SDK in your React Native project (see [Setup](/rn-codepush/setup/)).
+2. Produce a native build that includes the SDK and the deployment key you want to target.
+3. Install that build on the devices you expect to receive updates — local dev machines or QA devices for **Staging**, App Store / Google Play for **Production**.
+4. Only then start shipping JS changes to that deployment as OTA updates.
+
+For Staging validation this usually just means running a fresh debug build on a test device; no store release is required. For Production, end users must actually update to the new store binary before they can receive anything CodePush publishes.
+
+After that, the usual pattern — occasional native releases for native changes, OTA releases for everything else — applies.
+
 ## Deployment model
 
 CodePush organizes updates using **apps** and **deployments**.

--- a/content/rn-codepush/concepts.md
+++ b/content/rn-codepush/concepts.md
@@ -74,7 +74,7 @@ CodePush updates this **JavaScript bundle and its assets**. As long as JS remain
 
 ## What can and cannot be updated
 
-✅ Can Be Updated via CodePush (OTA-safe):
+Can Be Updated via CodePush (OTA-safe):
 
 * Fixing JavaScript bugs
 * UI or layout adjustments
@@ -85,7 +85,7 @@ CodePush updates this **JavaScript bundle and its assets**. As long as JS remain
 
 These updates modify only the JavaScript bundle, so they can be safely delivered over the air. 
 
-❌ Require a New App Release
+Require a New App Release
 
 * Adding or modifying native modules
 * Upgrading React Native or native dependencies

--- a/content/rn-codepush/debugging-and-common-issues.md
+++ b/content/rn-codepush/debugging-and-common-issues.md
@@ -10,6 +10,7 @@ This section covers tools and techniques for diagnosing problems with OTA update
 
 When an update does not install or behaves unexpectedly, the issue is usually caused by one of the following:
 
+- a native binary without the CodePush SDK (first-time rollout)
 - a configuration mismatch
 - a version targeting problem
 - an SDK integration issue
@@ -122,6 +123,26 @@ Most monitoring platforms provide documentation for integrating CodePush release
 ## Common update failures
 
 The following issues are common when releasing CodePush updates.
+
+### Native binary without the CodePush SDK
+
+OTA updates only install on native builds that already contain the CodePush SDK. If the SDK was recently added to the project but the store binary users have installed predates that change, `release-react` will publish successfully and the update will appear in the deployment history, but **no client will pick it up** — there is nothing on the device to check the server.
+
+Symptoms:
+
+- Release shows in `code-push deployment history <APP> <DEPLOYMENT>` with active installs staying at zero.
+- No `[CodePush]` log entries appear on device when you open the app, even with good network connectivity.
+- The issue affects all users, not a subset.
+
+Fix:
+
+1. Confirm the SDK is wired up in the React Native project (see [Setup](/rn-codepush/setup/#add-codepush-to-a-react-native-app)).
+2. Rebuild the app so the native binary includes the SDK, and install that build on the devices that should receive updates:
+   - **Staging:** a fresh dev or internal-distribution build on your test devices is enough; no store release needed.
+   - **Production:** publish to the App Store / Google Play and wait for users to update.
+3. Subsequent `release-react` calls against the matching deployment will then reach those devices over the air.
+
+This is a one-time gate per deployment when first adopting CodePush; after devices are on an SDK-enabled binary, the regular OTA flow applies. See [Concepts](/rn-codepush/concepts/#prerequisite-a-native-build-with-the-sdk) for the underlying reason.
 
 ### Wrong binary version targeting
 

--- a/content/rn-codepush/releasing-updates.md
+++ b/content/rn-codepush/releasing-updates.md
@@ -17,13 +17,17 @@ CodePush updates are not managed through the Codemagic UI. All releases, promoti
 
 ## Overview
 
-After integrating the CodePush SDK into your React Native app as explained in the [previous sectio](http://localhost:1313/rn-codepush/setup/#add-codepush-to-a-react-native-app)n, you can ship updates without rebuilding or resubmitting your app to the App Store or Google Play.
+After integrating the CodePush SDK into your React Native app as explained in the [previous section](/rn-codepush/setup/#add-codepush-to-a-react-native-app), you can ship updates without rebuilding or resubmitting your app to the App Store or Google Play.
 
 CodePush delivers:
 * Updated JavaScript bundles
 * App assets (e.g. images, fonts)
 
 These updates are downloaded silently by users’ devices (depending on your install mode).
+
+{{<notebox>}}
+**Prerequisite:** OTA updates only install on native builds that already contain the CodePush SDK and the matching deployment key. For **Staging**, your test devices need an SDK-enabled build carrying the Staging key — usually a local debug or internal-distribution build; no store release required. For **Production**, end users must be on a store build that includes the SDK, so the first Production rollout of CodePush always requires an App Store / Google Play release and waiting for users to update. See [Setup](/rn-codepush/setup/) and [Concepts](/rn-codepush/concepts/#prerequisite-a-native-build-with-the-sdk).
+{{</notebox>}}
 
 ## Recommended Workflow
 

--- a/content/rn-codepush/releasing-updates.md
+++ b/content/rn-codepush/releasing-updates.md
@@ -85,7 +85,7 @@ Think of this as a single pipeline with two decision points:
 
 CodePush delivers only JavaScript runtime assets and the files required by the application’s JS layer.
 
-A typical update includes:
+A typical update includes only changed files and assets, such as:
 
 * JavaScript bundle
 * Static assets (images, fonts, etc.)
@@ -94,6 +94,12 @@ A typical update includes:
 CodePush does not include native binaries such as **.apk** or **.ipa** files. OTA updates are limited to changes in the JavaScript layer only.
 
 Any modification involving native code (e.g. Swift, Objective-C, Java, Kotlin, or native modules) must be released through the App Store or Google Play.
+
+### Delta updates
+
+CodePush uses delta updates (file-level diffs) for each release and delivers only the files or assets that changed.
+
+This means users download a lightweight delta package instead of the full JavaScript bundle and all assets every time, resulting in faster updates and smaller downloads for users.
 
 ## Version control
 

--- a/content/rn-codepush/setup.md
+++ b/content/rn-codepush/setup.md
@@ -346,13 +346,6 @@ This single command:
 
 For the full release workflow, see [Releasing updates](/rn-codepush/releasing-updates/).
 
-✅ Best Practices
-* Use Environment Variables – Avoid hardcoding deployment keys.
-* Separate Staging and Production Keys – Always validate updates in Staging before promoting to Production.
-* Confirm Connectivity – After configuration, make sure the app can fetch updates from the server by testing a Staging release.
-
-Properly configuring the server URL and deployment keys ensures that CodePush can deliver OTA updates reliably and safely for each platform.
-
 ## Next steps
 
 After completing setup, use the following sections to continue:

--- a/content/yaml-quick-start/building-a-react-native-app.md
+++ b/content/yaml-quick-start/building-a-react-native-app.md
@@ -275,7 +275,7 @@ If you are going to publish your app to App Store Connect or Google Play, each u
 
 ## OTA Updates with CodePush
 
-Our hosted CodePush service lets users publish OTA updates for React Native projects without going via the App or Play store. Read the [concepts page](../rn-codepush/codepush-concepts/) for how it works, or the [setup page](../rn-codepush/setup-codepush/) to get started.
+Our hosted CodePush service lets you  publish OTA updates for React Native projects directly to users' devices, without going via the App Store or Google Play. Read the [concepts page](../rn-codepush/concepts/) for how it works, or the [setup page](../rn-codepush/setup/) to get started.
 
 ## Conclusion
 Having followed all of the above steps, you now have a working `codemagic.yaml` file that allows you to build, code sign, automatically version and publish your project using Codemagic CI/CD.

--- a/content/yaml-quick-start/building-a-react-native-app.md
+++ b/content/yaml-quick-start/building-a-react-native-app.md
@@ -273,6 +273,9 @@ If you are going to publish your app to App Store Connect or Google Play, each u
 
 {{< include "/partials/publishing-android-ios.md" >}}
 
+## OTA Updates with CodePush
+
+Our hosted CodePush service lets users publish OTA updates for React Native projects without going via the App or Play store. Read the [concepts page](../rn-codepush/codepush-concepts/) for how it works, or the [setup page](../rn-codepush/setup-codepush/) to get started.
 
 ## Conclusion
 Having followed all of the above steps, you now have a working `codemagic.yaml` file that allows you to build, code sign, automatically version and publish your project using Codemagic CI/CD.


### PR DESCRIPTION
I figured it would be best for the Analytics page to specifically mention the options of getting stats via the UI, CLI or API. Plus, I've added a mention of CodePush into the RN quickstart.