### PR TITLE
Better generation of md urls

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,13 +7,3 @@ cd "${0%/*}"
 rm -rf public/
 
 hugo --minify
-
-# Rename slug/index.md → slug.md to match the clean .md URL convention.
-# Only processes directories that also contain an index.html, so section
-# indexes and other non-page artifacts are left untouched.
-find public -mindepth 2 -name "index.md" | while IFS= read -r f; do
-  dir=$(dirname "$f")
-  if [ -f "$dir/index.html" ]; then
-    mv "$f" "$(dirname "$dir")/$(basename "$dir").md"
-  fi
-done

--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ outputFormats:
     mediaType: text/markdown
     isHTML: false
     isPlainText: true
-    notAlternative: true
+    notAlternative: false
     ugly: true
   LLMSTxt:
     mediaType: text/plain

--- a/config.yaml
+++ b/config.yaml
@@ -24,9 +24,10 @@ imaging:
 outputFormats:
   MarkdownPage:
     mediaType: text/markdown
-    baseName: index
+    isHTML: false
     isPlainText: true
     notAlternative: true
+    ugly: true
   LLMSTxt:
     mediaType: text/plain
     baseName: llms

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
-        {{ .Render "head" }}    
+        {{ .Render "head" }}  
+        {{- with .OutputFormats.Get "MarkdownPage" }}
+  <link rel="alternate" type="text/markdown" href="{{ .Permalink }}" title="{{ $.Title }} Markdown" />
+{{- end }}  
     </head>
     <body class="page page--home">
         {{ partial "header" . }}

--- a/layouts/_default/single.markdownpage.md
+++ b/layouts/_default/single.markdownpage.md
@@ -96,7 +96,7 @@
 {{- if in $processedContent "$$$" -}}
   {{- /* Strip out the $$$variable-name$$$ formatting, leaving only the value */ -}}
   {{- /* Matches: $$$id$$$value$$$ -> value */ -}}
-  {{- $processedContent = replaceRE `\$\$\$[a-zA-Z0-9_-]+\$\$\$(.*?)\$\$$` "$1" $processedContent -}}
+  {{- $processedContent = replaceRE `\$\$\$[a-zA-Z0-9_-]+\$\$\$(.*?)\$\$\$` "$1" $processedContent -}}
 {{- end -}}
 
 

--- a/layouts/_default/single.markdownpage.md
+++ b/layouts/_default/single.markdownpage.md
@@ -6,4 +6,130 @@
 {{ with .Params.description }}
 > {{ . }}
 {{ end }}
-{{ .RawContent -}}
+
+{{- /* Initialize scratchpad */ -}}
+{{- $.Scratch.Set "content" .RawContent -}}
+
+{{/* =========================================================
+   STAGE 1: EXPAND NESTED INCLUDES (RECURSIVE & SCOPE-SAFE)
+   ========================================================= */}}
+{{- range seq 10 -}}
+  {{- $currentContent := $.Scratch.Get "content" -}}
+  {{- if in $currentContent "{{< include \"" -}}
+    {{- $chunks := split $currentContent "{{< include \"" -}}
+    {{- $.Scratch.Set "finalContent" (index $chunks 0) -}}
+    
+    {{- range $idx, $chunk := $chunks -}}
+      {{- if gt $idx 0 -}}
+        {{- $parts := split $chunk "\" >}}" -}}
+        {{- $path := index $parts 0 -}}
+        {{- $restOfText := index $parts 1 -}}
+        
+        {{- $includePage := $.Site.GetPage $path -}}
+        {{- $injectedContent := "" -}}
+        {{- if $includePage -}}
+          {{- $injectedContent = $includePage.RawContent -}}
+        {{- else -}}
+          {{- $cleanPath := replace $path "/partials/" "" -}}
+          {{- if templates.Exists (printf "partials/%s" $cleanPath) -}}
+            {{- $injectedContent = partial $cleanPath $ -}}
+          {{- end -}}
+        {{- end -}}
+        
+        {{- $runningContent := $.Scratch.Get "finalContent" -}}
+        {{- $.Scratch.Set "finalContent" (printf "%s%s%s" $runningContent $injectedContent $restOfText) -}}
+      {{- end -}}
+    {{- end -}}
+    
+    {{- $.Scratch.Set "content" ($.Scratch.Get "finalContent") -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{/* =========================================================
+   STAGE 2: FLATTEN TABS & CLEAN WRAPPER TAGS
+   ========================================================= */}}
+{{- $processedContent := $.Scratch.Get "content" -}}
+
+{{- if in $processedContent "{{< tab header=\"" -}}
+  {{- $tabChunks := split $processedContent "{{< tab header=\"" -}}
+  {{- $.Scratch.Set "flattenedTabs" (index $tabChunks 0) -}}
+  
+  {{- range $idx, $chunk := $tabChunks -}}
+    {{- if gt $idx 0 -}}
+      {{- $parts := split $chunk "\" >}}" -}}
+      {{- $headerName := index $parts 0 -}}
+      {{- $tabBody := index $parts 1 -}}
+      
+      {{- $runningTabs := $.Scratch.Get "flattenedTabs" -}}
+      {{- $.Scratch.Set "flattenedTabs" (printf "%s\n\n### Option: %s\n\n%s" $runningTabs $headerName $tabBody) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $processedContent = $.Scratch.Get "flattenedTabs" -}}
+{{- end -}}
+
+{{- $processedContent = replace $processedContent "{{< tabpane >}}" "" -}}
+{{- $processedContent = replace $processedContent "{{< /tabpane >}}" "" -}}
+{{- $processedContent = replace $processedContent "{{<markdown>}}" "" -}}
+{{- $processedContent = replace $processedContent "{{</markdown>}}" "" -}}
+{{- $processedContent = replace $processedContent "{{< /tab >}}" "" -}}
+
+
+{{/* =========================================================
+   STAGE 3: CONVERT ALL HIGHLIGHT VARIANTS TO MARKDOWN CODEBLOCKS
+   ========================================================= */}}
+{{- /* Step A: Normalize all opening tags (highlight & highlight-editable) to uniform markdown syntax */ -}}
+{{- $processedContent = replaceRE `\{\{\s*<\s*highlight\s+([a-zA-Z0-9_-]+)[^>]*>\s*\}\}` "\n```$1\n" $processedContent -}}
+{{- $processedContent = replaceRE `\{\{\s*<\s*highlight-editable\s+([a-zA-Z0-9_-]+)[^>]*>\s*\}\}` "\n```$1\n" $processedContent -}}
+
+{{- /* Step B: Normalize all closing tags to a temporary uniform string to guarantee we catch them all together */ -}}
+{{- $processedContent = replaceRE `\{\{\s*<\s*/highlight\s*>\s*\}\}` "{{</closeblock>}}" $processedContent -}}
+{{- $processedContent = replaceRE `\{\{\s*<\s*/highlight-editable\s*>\s*\}\}` "{{</closeblock>}}" $processedContent -}}
+
+{{- /* Step C: Safely replace all uniform closing tags with clean markdown backticks */ -}}
+{{- $processedContent = replace $processedContent "{{</closeblock>}}" "\n```\n" -}}
+
+
+{{/* =========================================================
+   STAGE 4: STRIP VARIABLES FROM EDITABLE CODE BLOCKS
+   ========================================================= */}}
+{{- if in $processedContent "$$$" -}}
+  {{- /* Strip out the $$$variable-name$$$ formatting, leaving only the value */ -}}
+  {{- /* Matches: $$$id$$$value$$$ -> value */ -}}
+  {{- $processedContent = replaceRE `\$\$\$[a-zA-Z0-9_-]+\$\$\$(.*?)\$\$$` "$1" $processedContent -}}
+{{- end -}}
+
+
+{{/* =========================================================
+   STAGE 5: CONVERT NOTEBOXES TO MARKDOWN BLOCKQUOTES
+   ========================================================= */}}
+{{- if in $processedContent "notebox" -}}
+  {{- /* Standardize tags */ -}}
+  {{- $processedContent = replaceRE `\{\{\s*<\s*notebox\s*>\s*\}\}` "{{<notebox>}}" $processedContent -}}
+  {{- $processedContent = replaceRE `\{\{\s*<\s*/notebox\s*>\s*\}\}` "{{</notebox>}}" $processedContent -}}
+  
+  {{- /* Split by the opening notebox tag to cleanly prepend blockquote markers to every line inside */ -}}
+  {{- $noteChunks := split $processedContent "{{<notebox>}}" -}}
+  {{- $.Scratch.Set "cleanNotes" (index $noteChunks 0) -}}
+  
+  {{- range $idx, $chunk := $noteChunks -}}
+    {{- if gt $idx 0 -}}
+      {{- $parts := split $chunk "{{</notebox>}}" -}}
+      {{- $noteBody := index $parts 0 -}}
+      {{- $restOfText := index $parts 1 -}}
+      
+      {{- /* Prepend > to each line within the note block */ -}}
+      {{- $blockquoteLines := slice -}}
+      {{- range (split $noteBody "\n") -}}
+         {{- $blockquoteLines = $blockquoteLines | append (printf "> %s" .) -}}
+      {{- end -}}
+      {{- $formattedNote := delimit $blockquoteLines "\n" -}}
+      
+      {{- $runningNotes := $.Scratch.Get "cleanNotes" -}}
+      {{- $.Scratch.Set "cleanNotes" (printf "%s\n\n%s\n\n%s" $runningNotes $formattedNote $restOfText) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $processedContent = $.Scratch.Get "cleanNotes" -}}
+{{- end -}}
+
+{{ $processedContent }}


### PR DESCRIPTION
- markdown pages automatically generated by hugo
- html pages referencing markdown as alternative format in <head>
- markdown output cleaned to replace the most common shortcodes with standard ones. Replaces 'highlight' (code block), notebox and expands all tabs