### PR TITLE
Move personal access token

### DIFF
--- a/content/getting-started/about-codemagic.md
+++ b/content/getting-started/about-codemagic.md
@@ -65,7 +65,3 @@ Full pricing details can be found on our pricing page [here](https://docs.codema
 ## Blog
 
 The [Codemagic blog](https://blog.codemagic.io/) is a great resource that covers a multitude of technical subjects related to CI/CD ranging from code signing and publishing to general application development.
-
-## Newsletter
-
-To stay updated with the latest news and updates about the Codemagic product, subscribe to our Newsletter. You can do this by clicking on the "Sign me up for newsletter" checkbox on your User Preferences page.

--- a/content/getting-started/faq.md
+++ b/content/getting-started/faq.md
@@ -78,7 +78,7 @@ For customers who require predictable and stable performance, dedicated hosts ar
 
 Each Codemagic user has their own personal API token. There is no shared API token at the team level, so you should always use the token from your personal account, even when working within a team.
 
-Navigate to **Account settings > API token > Show** to get your API token.
+Navigate to **Account settings > API token** to get your API token.
 
 ## How to delete a Codemagic account?
 If you need to delete your Codemagic account, select **Personal account** in the menu and navigate to **Settings** > **Danger zone** > **Delete account**.

--- a/content/getting-started/faq.md
+++ b/content/getting-started/faq.md
@@ -75,9 +75,10 @@ Because of this shared model, we cannot guarantee consistent performance at all 
 For customers who require predictable and stable performance, dedicated hosts are recommended. In such setups, hardware resources are reserved, and customers can explicitly configure their environment to run a single virtual machine per physical host, eliminating resource contention.
 
 ## Where can I find the Codemagic API Token?
+
 Each Codemagic user has their own personal API token. There is no shared API token at the team level, so you should always use the token from your personal account, even when working within a team.
 
-Select **Personal account** in the menu and navigate to **Settings** > **Integrations** > **Codemagic API** > **Show**
+Navigate to **Account settings > API token > Show** to get your API token.
 
 ## How to delete a Codemagic account?
 If you need to delete your Codemagic account, select **Personal account** in the menu and navigate to **Settings** > **Danger zone** > **Delete account**.

--- a/content/rest-api/codemagic-rest-api.md
+++ b/content/rest-api/codemagic-rest-api.md
@@ -17,7 +17,7 @@ Authentication with Codemagic APIs is performed using a **Codemagic API token**.
 
 The Codemagic API token is a personal token that is unique to each Codemagic user. The actions permitted by the token are determined by the user’s role within the team.
 
-To find your API token, select **Personal account** from the left navigation bar team selection, then click **Settings > Integrations > Codemagic API > Show**. 
+To find your API token, navigate to **Account settings > API token**. 
 
 When making API calls, include the API token in the `x-auth-token` request header. For security reasons, we recommend storing the token as an environment variable and referencing it in your requests, rather than embedding the token value directly in your code or workflows. For example:
 

--- a/content/yaml-notification/telegram.md
+++ b/content/yaml-notification/telegram.md
@@ -24,7 +24,7 @@ Add the following environment variables to your project settings in Codemagic:
 
 - **TELEGRAM_BOT_TOKEN**: Your Telegram bot token
 - **TELEGRAM_CHAT_ID**: The ID of the chat where the bot will send notifications
-- **CODEMAGIC_API_TOKEN**: Your Codemagic API token (found under Personal account > Settings > Integrations > Codemagic API)
+- **CODEMAGIC_API_TOKEN**: Your Codemagic API token (found under **Account settings > API token**)
 
 ### Setup Codemagic Configuration
 

--- a/content/yaml-quick-start/white-label-getting-started.md
+++ b/content/yaml-quick-start/white-label-getting-started.md
@@ -418,7 +418,7 @@ The Codemagic REST API is used in a white-label workflow to trigger builds for e
 
 To trigger a build using the Codemagic REST API, you need your API access token, the application id, and the workflow id. 
 
-- The access token is available in the Codemagic UI in **Account settings > API token**. > PLACEHOLDER2 > Codemagic API > Show**. You can then store this as an environment variable if you are calling the REST API from other workflows.
+- The access token is available in the Codemagic UI in **Account settings > API token**. You can then store this as an environment variable if you are calling the REST API from other workflows.
 - Once you have added your app in Codemagic, open its settings and copy the **application id** from the browser address bar - `https://codemagic.io/app/<APP_ID>/settings`
 - The workflow id is the string value you assigned to the `name` property e.g "ios-qa-build"
 

--- a/content/yaml-quick-start/white-label-getting-started.md
+++ b/content/yaml-quick-start/white-label-getting-started.md
@@ -59,7 +59,7 @@ To add these values you can either use the [Codemagic UI](https://docs.codemagic
 
 To add an environment variable using the Codemagic REST API, you need your API access token, the application id, the client group unique name, and the variable name and value. 
 
-- The access token is available in the Codemagic UI in your personal account settings. Select your personal account and go to **Settings > Integrations > Codemagic API > Show**. You can then store this as an environment variable if you are calling the REST API from other workflows.
+- The access token is available in the Codemagic UI in **Account settings > API token**. You can then store this as an environment variable if you are calling the REST API from other workflows.
 - Once you have added your app in Codemagic, open its settings and copy the **application id** from the browser address bar - `https://codemagic.io/app/<APP_ID>/settings`
 - The client group name is the group that holds all variables for this client e.g. `WL_001`, `WL_002`.
 
@@ -418,7 +418,7 @@ The Codemagic REST API is used in a white-label workflow to trigger builds for e
 
 To trigger a build using the Codemagic REST API, you need your API access token, the application id, and the workflow id. 
 
-- The access token is available in the Codemagic UI in your personal account settings. Select your personal account and go to **Settings > Integrations > Codemagic API > Show**. You can then store this as an environment variable if you are calling the REST API from other workflows.
+- The access token is available in the Codemagic UI in **Account settings > API token**. > PLACEHOLDER2 > Codemagic API > Show**. You can then store this as an environment variable if you are calling the REST API from other workflows.
 - Once you have added your app in Codemagic, open its settings and copy the **application id** from the browser address bar - `https://codemagic.io/app/<APP_ID>/settings`
 - The workflow id is the string value you assigned to the `name` property e.g "ios-qa-build"
 

--- a/content/yaml-running-builds/fan-out-fan-in-builds.md
+++ b/content/yaml-running-builds/fan-out-fan-in-builds.md
@@ -56,7 +56,7 @@ Codemagic does not have a built-in DAG (directed acyclic graph) UI for declaring
 | **Item** | **Where to get it** |
 |---|---|
 | Codemagic account (Team plan or higher) | [Sign up for free](https://codemagic.io/signup) |
-| Codemagic API token | **Personal Account → Settings → Integrations → Codemagic API → Show** |
+| Codemagic API token | **Account settings → API token** |
 | App ID for your app | From the browser address bar (e.g. `https://codemagic.io/app/<APP_ID>/settings`) after selecting **Applications** → **Open app settings (cogwheel icon)** |
 | Sufficient concurrencies | **Team Settings → Concurrencies** — you need enough concurrent slots for the main workflow plus parallel build branches |
 


### PR DESCRIPTION
- "User preferences" is renamed to "Account settings"
- Personal access token is moved from personal team settings to Account settings
- Also removed the section about signing up to newsletter since it's no longer there in the UI