### PR TITLE
Update burstable concurrency example

### DIFF
--- a/content/billing/pricing.md
+++ b/content/billing/pricing.md
@@ -187,7 +187,7 @@ Burstable concurrencies allow you to use more concurrencies than you otherwise w
 
 To determine which concurrencies are bursted and which ones are not we divide billing period into 5 second intervals and sample concurrency usage every 5 seconds. We then reorder this graph in descending order so the left of the graph is consisting of high use of concurrency and tail end of the graph is low use of concurrency. We then discard 5% of the high use as “bursting” and consider only the use at 95th percentile.
 
-If you subscribe to 20 concurrencies and consume 10 within the 95th percentile, then you pay full price for 10 and **1/3** of the price for the remaining 10.
+If you subscribe to 10 concurrencies and consume 4 within the 95th percentile, then you pay full price for 4 and **1/3** of the price for the remaining 6.
 
 ### Pricing for Enterprises
 


### PR DESCRIPTION
update burstable concurrency example to make it clear you can subscribe to 10 concurrencies of which 4 can be consumed within baseline and 6 bursted at 1/3 the rate.