### PR TITLE
removing tab filtering

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -176,13 +176,23 @@ const getResultHtml = (algoliaResultList, query) => {
         return true
     })
 
+    if (!filteredResults.length) {
+        return createHtmlElement('div', { className: 'no-results-message' }, [
+            createHtmlElement('p', { innerText: `No results matching "${query}"` }),
+            createHtmlElement('p', {
+                className: 'support-message',
+                innerHTML:
+                    "Don't see what you're looking for? <a href='https://codemagic.io/contact/'>Contact us</a> or let us know via support chat widget in <a href='https://codemagic.io/apps'>app</a>.",
+            }),
+        ])
+    }
+
     const tabLabel = preference === 'yaml' ? 'codemagic.yaml' : 'Workflow Editor'
     const otherTabLabel = preference === 'yaml' ? 'Workflow Editor' : 'codemagic.yaml'
-    const notice = createHtmlElement('li', { className: 'search-tab-notice' }, [
-        createHtmlElement('p', {
-            innerText: `Showing results for ${tabLabel}. Switch tabs on the left to search the ${otherTabLabel} results.`,
-        }),
-    ])
+    const notice = createHtmlElement('li', {
+        className: 'search-tab-notice',
+        innerText: `Showing results for ${tabLabel}. Switch tabs on the left to search the ${otherTabLabel} results.`,
+    })
 
     const results = filteredResults.map((result) => {
         const subtitle = result._highlightResult?.subtitle?.value ?? ''

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -169,36 +169,28 @@ const getResultHtml = (algoliaResultList, query) => {
         ])
     }
 
-    const getConfigBadge = (uri) => {
-        if (uri.startsWith('/yaml'))
-            return createHtmlElement('span', {
-                className: 'result-badge result-badge--yaml',
-                innerText: 'codemagic.yaml',
-            })
-        if (uri.startsWith('/flutter'))
-            return createHtmlElement('span', {
-                className: 'result-badge result-badge--workflow',
-                innerText: 'Workflow Editor',
-            })
-        return null
-    }
-
     const preference = window.localStorage.getItem('preferred-configuration') ?? 'yaml'
-    const getTabScore = (uri) => {
-        if (preference === 'yaml' && (uri.startsWith('/yaml') || uri.startsWith('/rn-codepush'))) return 0
-        if (preference === 'flutter' && uri.startsWith('/flutter')) return 0
-        return 1
-    }
-    const sortedResults = algoliaResultList.slice().sort((a, b) => getTabScore(a.uri) - getTabScore(b.uri))
+    const filteredResults = algoliaResultList.filter((result) => {
+        if (preference === 'yaml') return !result.uri.startsWith('/flutter')
+        if (preference === 'flutter') return !result.uri.startsWith('/yaml') && !result.uri.startsWith('/rn-codepush')
+        return true
+    })
 
-    const results = sortedResults.map((result) => {
+    const tabLabel = preference === 'yaml' ? 'codemagic.yaml' : 'Workflow Editor'
+    const otherTabLabel = preference === 'yaml' ? 'Workflow Editor' : 'codemagic.yaml'
+    const notice = createHtmlElement('li', { className: 'search-tab-notice' }, [
+        createHtmlElement('p', {
+            innerText: `Showing results for ${tabLabel}. Switch tabs on the left to search the ${otherTabLabel} results.`,
+        }),
+    ])
+
+    const results = filteredResults.map((result) => {
         const subtitle = result._highlightResult?.subtitle?.value ?? ''
         const pageTitle = result._highlightResult?.title?.value ?? result.title ?? ''
         return createHtmlElement('li', null, [
             createHtmlElement('a', { href: result.uri }, [
                 createHtmlElement('div', { className: 'title-row' }, [
                     createHtmlElement('p', { innerHTML: subtitle || pageTitle, className: 'title' }),
-                    getConfigBadge(result.uri),
                 ]),
                 subtitle ? createHtmlElement('p', { innerHTML: pageTitle, className: 'subtitle' }) : null,
                 createHtmlElement('p', {
@@ -224,7 +216,7 @@ const getResultHtml = (algoliaResultList, query) => {
         }),
     ])
 
-    return createHtmlElement('ul', null, [...results, supportLink])
+    return createHtmlElement('ul', null, [notice, ...results, supportLink])
 }
 
 const getResults = (query) =>

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -126,6 +126,17 @@
                 border-bottom: none;
             }
         }
+        .search-tab-notice {
+            font-size: 12px;
+            color: $grey-text-light;
+            padding: 10px 20px;
+            &::after {
+                display: none;
+            }
+            &:hover {
+                background-color: transparent;
+            }
+        }
         p {
             word-break: break-all;
         }

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -128,13 +128,26 @@
         }
         .search-tab-notice {
             font-size: 12px;
-            color: $grey-text-light;
-            padding: 10px 20px;
+            color: white;
+            background-color: $blue;
+            border-left: 3px solid darken($blue, 10%);
+            border-radius: 8px;
+            padding: 10px 14px;
+            margin: 0 0 4px 0;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            &::before {
+                content: 'ⓘ';
+                font-size: 14px;
+                line-height: 1.4;
+                flex-shrink: 0;
+            }
             &::after {
                 display: none;
             }
             &:hover {
-                background-color: transparent;
+                background-color: $blue;
             }
         }
         p {
@@ -240,4 +253,5 @@
             }
         }
     }
+
 }

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -8,6 +8,12 @@
     {{- $isIntro := eq $i 0 }}
     {{- $heading := cond $isIntro ($page.Description | default "") (index (split $section "\n") 0 | strings.TrimSpace) }}
     {{- $rawText := cond $isIntro $section (delimit (after 1 (split $section "\n")) "\n") }}
+    {{- range findRE `\{\{<\s*include\s+"([^"]+)"\s*>\}\}` $rawText }}
+      {{- $includePath := replaceRE `\{\{<\s*include\s+"([^"]+)"\s*>\}\}` "$1" . }}
+      {{- $fileContent := readFile (printf "content%s" $includePath) }}
+      {{- $fileContent = replaceRE `(?s)^\s*---.*?---\s*` "" $fileContent }}
+      {{- $rawText = replace $rawText . $fileContent }}
+    {{- end }}
     {{- $text := partial "clean-text.html" $rawText }}
     {{- $anchor := cond $isIntro "" ($heading | urlize) }}
     {{- $recordUri := cond (or $isIntro (not $anchor)) $uri (printf "%s#%s" $uri $anchor) }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,181 @@
+{
+    "name": "codemagic-docs",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "codemagic-docs",
+            "version": "1.0.0",
+            "devDependencies": {
+                "algoliasearch": "^4.14.2"
+            }
+        },
+        "node_modules/@algolia/cache-browser-local-storage": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
+            "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/cache-common": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/cache-common": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
+            "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@algolia/cache-in-memory": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
+            "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/cache-common": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/client-account": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
+            "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "4.14.2",
+                "@algolia/client-search": "4.14.2",
+                "@algolia/transporter": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/client-analytics": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
+            "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "4.14.2",
+                "@algolia/client-search": "4.14.2",
+                "@algolia/requester-common": "4.14.2",
+                "@algolia/transporter": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/client-common": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
+            "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/requester-common": "4.14.2",
+                "@algolia/transporter": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/client-personalization": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
+            "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "4.14.2",
+                "@algolia/requester-common": "4.14.2",
+                "@algolia/transporter": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/client-search": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
+            "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/client-common": "4.14.2",
+                "@algolia/requester-common": "4.14.2",
+                "@algolia/transporter": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/logger-common": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
+            "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@algolia/logger-console": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
+            "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/logger-common": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/requester-browser-xhr": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
+            "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/requester-common": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/requester-common": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
+            "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@algolia/requester-node-http": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
+            "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/requester-common": "4.14.2"
+            }
+        },
+        "node_modules/@algolia/transporter": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
+            "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/cache-common": "4.14.2",
+                "@algolia/logger-common": "4.14.2",
+                "@algolia/requester-common": "4.14.2"
+            }
+        },
+        "node_modules/algoliasearch": {
+            "version": "4.14.2",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
+            "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/cache-browser-local-storage": "4.14.2",
+                "@algolia/cache-common": "4.14.2",
+                "@algolia/cache-in-memory": "4.14.2",
+                "@algolia/client-account": "4.14.2",
+                "@algolia/client-analytics": "4.14.2",
+                "@algolia/client-common": "4.14.2",
+                "@algolia/client-personalization": "4.14.2",
+                "@algolia/client-search": "4.14.2",
+                "@algolia/logger-common": "4.14.2",
+                "@algolia/logger-console": "4.14.2",
+                "@algolia/requester-browser-xhr": "4.14.2",
+                "@algolia/requester-common": "4.14.2",
+                "@algolia/requester-node-http": "4.14.2",
+                "@algolia/transporter": "4.14.2"
+            }
+        }
+    }
+}


### PR DESCRIPTION
*  Resolves {{< include >}} shortcodes before indexing, reads the referenced partial file, strips its frontmatter, and inlines the content so sections backed by partials are properly indexed in Algolia
* Tab filter: results are filtered to only show the current tab's pages + general pages
* Removed per-result badges
* Added a small notice at the top of results 