### PR TITLE
docs: note Appflow Live Updates migration path on Capgo integration

### DIFF
--- a/content/integrations/capgo-integration.md
+++ b/content/integrations/capgo-integration.md
@@ -8,6 +8,8 @@ weight: 5
 
 A sample project that shows how to configure Capgo integration is available [in our Sample projects repository](https://github.com/codemagic-ci-cd/codemagic-sample-projects/tree/main/integrations/capgo_integration_demo_project).
 
+If you are migrating from Ionic Appflow Live Updates, Capgo is a Capacitor live-update option you can wire into the same Codemagic workflows. For Appflow SDK uninstall steps on Capacitor, see [OTA updates for Ionic Capacitor apps](../rn-codepush/ionic-capacitor-codepush/).
+
 
 ## Configuring Capgo in Codemagic
 

--- a/content/integrations/capgo-integration.md
+++ b/content/integrations/capgo-integration.md
@@ -4,12 +4,9 @@ description: How to integrate your workflows with Capgo using codemagic.yaml
 weight: 5
 ---
 
-[Capgo](https://capgo.app/) allows you to deploy live updates for Capacitor apps after they have been published to the App Store or Google Play.
+[Capgo](https://capgo.app/) is a Capacitor live-update option you can wire into your Codemagic workflows. It allows you to deploy live updates for Capacitor apps after they have been published to the App Store or Google Play. 
 
 A sample project that shows how to configure Capgo integration is available [in our Sample projects repository](https://github.com/codemagic-ci-cd/codemagic-sample-projects/tree/main/integrations/capgo_integration_demo_project).
-
-If you are migrating from Ionic Appflow Live Updates, Capgo is a Capacitor live-update option you can wire into the same Codemagic workflows. For Appflow SDK uninstall steps on Capacitor, see [OTA updates for Ionic Capacitor apps](../rn-codepush/ionic-capacitor-codepush/).
-
 
 ## Configuring Capgo in Codemagic
 


### PR DESCRIPTION
## Why

Capacitor teams leaving Ionic Appflow Live Updates often land on Codemagic docs for CI/CD + OTA. Codemagic already has a Capgo integration page and sample, but that page never mentions Appflow migration.

## What changes

One short paragraph on `content/integrations/capgo-integration.md` after the sample-project intro:

- Capgo is a Capacitor live-update option for the same Codemagic workflows
- Link to the existing Capacitor CodePush / Appflow uninstall guide for SDK removal steps

No Capgo marketing beyond naming the existing integration. Appflow wording stays neutral (migration path only).

## Ask

Happy to drop the CodePush-guide link and keep only the Capgo sentence if that is easier to ship.